### PR TITLE
Example tweaks

### DIFF
--- a/build/example.js
+++ b/build/example.js
@@ -2099,49 +2099,50 @@ process.umask = function() { return 0; };
 },{}],6:[function(require,module,exports){
 "use strict";
 
-const V = require('gl-vec3');
-const V4 = require('gl-vec4');
+var V = require('gl-vec3');
+var V4 = require('gl-vec4');
 
-const vec3 = function(x, y, z) {
-	let v = V.create();
+var vec3 = function(x, y, z) {
+	var v = V.create();
 	if (x !== undefined) {
 		V.set(v, x, y, z);
 	}
 	return v;
 }
 
-var createPositionsForMeshgrid = function([xs, ys, zs]) {
-  var positions = [];
-  for (var z=0; z<zs.length; z++) {
-    for (var y=0; y<ys.length; y++) {
-      for (var x=0; x<xs.length; x++) {
-        positions.push([zs[z], ys[y], xs[x]]);
-      }
-    }
-  }
-  return positions;
+var createPositionsForMeshgrid = function(meshgrid) {
+	var xs = meshgrid[0], ys = meshgrid[1], zs = meshgrid[2];
+	var positions = [];
+	for (var z=0; z<zs.length; z++) {
+		for (var y=0; y<ys.length; y++) {
+			for (var x=0; x<xs.length; x++) {
+				positions.push([zs[z], ys[y], xs[x]]);
+			}
+		}
+	}
+	return positions;
 };
 
-const findLastSmallerIndex = function(points, v) {
-  for (var i=0; i<points.length; i++) {
-    if (points[i] >= v) {
-      return i-1;
-    }
-  }
-  return i;
+var findLastSmallerIndex = function(points, v) {
+	for (var i=0; i<points.length; i++) {
+		if (points[i] >= v) {
+			return i-1;
+		}
+	}
+	return i;
 };
 
-const tmp = V.create();
-const tmp2 = V.create();
+var tmp = V.create();
+var tmp2 = V.create();
 
-const clamp = function(v, min, max) {
+var clamp = function(v, min, max) {
 	return v < min ? min : (v > max ? max : v);
 };
 
-const sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
-	const x = point[0];
-	const y = point[1];
-	const z = point[2];
+var sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
+	var x = point[0];
+	var y = point[1];
+	var z = point[2];
 
 	var w = meshgrid[0].length;
 	var h = meshgrid[1].length;
@@ -2219,7 +2220,7 @@ const sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
 	return result;
 };
 
-const getOrthogonalVector = function(dst, v) {
+var getOrthogonalVector = function(dst, v) {
 	// Return up-vector for only-z vector.
 	if (v[0] === 0 && v[1] === 0) {
 		V.set(dst, 0, 1, 0);
@@ -2242,43 +2243,45 @@ module.exports = function(vectorfield, bounds) {
 	}
 	var meshgrid = vectorfield.meshgrid;
 	var vectors = vectorfield.vectors;
-	let geo = {
+	var geo = {
 		positions: [],
 		vertexIntensity: [],
+		vertexIntensityBounds: vectorfield.vertexIntensityBounds,
 		vertexNormals: [],
 		vectors: [],
 		cells: [],
+		coneOffset: vectorfield.coneOffset,
 		colormap: vectorfield.colormap
 	};
 
 	// Compute bounding box for the dataset.
 	// Compute maximum velocity for the dataset to use for scaling the cones.
-	let maxLen = 0;
-	let minX = 1/0, maxX = -1/0;
-	let minY = 1/0, maxY = -1/0;
-	let minZ = 1/0, maxZ = -1/0;
-	let v2 = null;
-	let positionVectors = [];
-	let minSeparation = 1/0;
-	for (let i = 0; i < positions.length; i++) {
-		let v1 = positions[i];
+	var maxNorm = 0;
+	var minX = 1/0, maxX = -1/0;
+	var minY = 1/0, maxY = -1/0;
+	var minZ = 1/0, maxZ = -1/0;
+	var v2 = null;
+	var positionVectors = [];
+	var minSeparation = 1/0;
+	for (var i = 0; i < positions.length; i++) {
+		var v1 = positions[i];
 		minX = Math.min(v1[0], minX);
 		maxX = Math.max(v1[0], maxX);
 		minY = Math.min(v1[1], minY);
 		maxY = Math.max(v1[1], maxY);
 		minZ = Math.min(v1[2], minZ);
 		maxZ = Math.max(v1[2], maxZ);
-		let u;
+		var u;
 		if (meshgrid) {
 			u = sampleMeshgrid(v1, vectors, meshgrid, true);
 		} else {
 			u = vectors[i];
 		}
-		if (V.length(u) > maxLen) {
-			maxLen = V.length(u);
+		if (V.length(u) > maxNorm) {
+			maxNorm = V.length(u);
 		}
 		if (v2) {
-			let separation = V.distance(v1, v2);
+			var separation = V.distance(v1, v2);
 			if (separation < minSeparation) {
 				minSeparation = separation;
 			}
@@ -2286,33 +2289,44 @@ module.exports = function(vectorfield, bounds) {
 		v2 = v1;
 		positionVectors.push(u);
 	}
-	let minV = [minX, minY, minZ];
-	let maxV = [maxX, maxY, maxZ];
+	var minV = [minX, minY, minZ];
+	var maxV = [maxX, maxY, maxZ];
 	if (bounds) {
 		bounds[0] = minV;
 		bounds[1] = maxV;
 	}
-	let scaleV = V.subtract(vec3(), maxV, minV);
-	let imaxLen = 1 / maxLen;
+	if (maxNorm === 0) {
+		maxNorm = 1;
+	}
+	// Inverted max norm would map vector with norm maxNorm to 1 coord space units in length
+	var invertedMaxNorm = 1 / maxNorm;
 
-	geo.vectorScale = imaxLen * minSeparation;
+	if (!isFinite(minSeparation) || isNaN(minSeparation)) {
+		minSeparation = 1.0;
+	}
 
-	let nml = vec3(0,1,0);
+	// Inverted max norm multiplied scaled by smallest found vector position distance:
+	// Maps a vector with norm maxNorm to minSeparation coord space units in length.
+	// In practice, scales maxNorm vectors so that they are just long enough to reach the adjacent vector position.
+	geo.vectorScale = invertedMaxNorm * minSeparation;
 
-	let coneScale = vectorfield.coneSize || 0.5;
+	var nml = vec3(0,1,0);
+
+	var coneScale = vectorfield.coneSize || 0.5;
 
 	if (vectorfield.absoluteConeSize) {
-		coneScale = vectorfield.absoluteConeSize * imaxLen;
+		coneScale = vectorfield.absoluteConeSize * invertedMaxNorm;
 	}
 
 	geo.coneScale = coneScale;
 
 	// Build the cone model.
-	for (let i = 0, j = 0; i < positions.length; i++) {
-		let [x,y,z] = positions[i];
-		let d = positionVectors[i];
-		let intensity = V.length(d) * imaxLen;
-		for (let k = 0, l = 8; k < l; k++) {
+	for (var i = 0, j = 0; i < positions.length; i++) {
+		var p = positions[i];
+		var x = p[0], y = p[1], z = p[2];
+		var d = positionVectors[i];
+		var intensity = V.length(d) * invertedMaxNorm;
+		for (var k = 0, l = 8; k < l; k++) {
 			geo.positions.push([x, y, z, j++]);
 			geo.positions.push([x, y, z, j++]);
 			geo.positions.push([x, y, z, j++]);
@@ -2333,7 +2347,7 @@ module.exports = function(vectorfield, bounds) {
 			geo.vertexNormals.push(nml, nml, nml);
 			geo.vertexNormals.push(nml, nml, nml);
 
-			let m = geo.positions.length;
+			var m = geo.positions.length;
 			geo.cells.push([m-6, m-5, m-4], [m-3, m-2, m-1]);
 		}
 	}
@@ -2342,6 +2356,7 @@ module.exports = function(vectorfield, bounds) {
 };
 
 module.exports.createConeMesh = require('./lib/conemesh');
+
 },{"./lib/conemesh":10,"gl-vec3":139,"gl-vec4":169}],7:[function(require,module,exports){
 var createCamera = require('3d-view-controls')
 var getBounds    = require('bound-points')
@@ -2389,7 +2404,7 @@ var mesh = createMesh(gl, conePlot)
 
 var select = createSelect(gl, [canvas.width, canvas.height])
 var tickSpacing = 5;
-var ticks = bounds[0].map((v,i) => {
+var ticks = bounds[0].map(function(v,i) {
   var arr = [];
   var firstTick = Math.ceil(bounds[0][i] / tickSpacing) * tickSpacing;
   var lastTick = Math.floor(bounds[1][i] / tickSpacing) * tickSpacing;
@@ -2688,6 +2703,7 @@ function SimplicialMesh(gl
 
   this.coneScale     = 2.0
   this.vectorScale   = 1.0
+  this.coneOffset    = 1.0 / 4.0;
 
   this._model       = identityMatrix
   this._view        = identityMatrix
@@ -2826,6 +2842,16 @@ proto.update = function(params) {
     this.fresnel = params.fresnel
   }
 
+  if (params.vectorScale !== undefined) {
+    this.vectorScale = params.vectorScale;
+  }
+  if (params.coneScale !== undefined) {
+    this.coneScale = params.coneScale;
+  }
+  if (params.coneOffset !== undefined) {
+    this.coneOffset = params.coneOffset;
+  }
+
   if(params.texture) {
     this.texture.dispose()
     this.texture = createTexture(gl, params.texture)
@@ -2843,13 +2869,6 @@ proto.update = function(params) {
 
   if(!positions || !cells || !vectors) {
     return
-  }
-
-  if (params.vectorScale) {
-    this.vectorScale = params.vectorScale;
-  }
-  if (params.coneScale) {
-    this.coneScale = params.coneScale;
   }
 
   var tPos = []
@@ -3206,6 +3225,7 @@ proto.drawTransparent = proto.draw = function(params) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     contourColor: this.contourColor,
 
@@ -3306,6 +3326,7 @@ proto.drawPick = function(params) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     pickId:     this.pickId / 255.0,
   }
@@ -3383,6 +3404,7 @@ proto.pick = function(pickData) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     dataCoordinate: this.positions[cell[data[0]]]
   }
@@ -3425,7 +3447,9 @@ proto.dispose = function() {
 }
 
 function createMeshShader(gl) {
-  var shader = createShader(gl, meshShader.vertex, meshShader.fragment)
+  // need to pass meshShader attributes manually,
+  // to make this work on etpinard's Ubuntu Thinkpad
+  var shader = createShader(gl, meshShader.vertex, meshShader.fragment, null, meshShader.attributes)
   shader.attributes.position.location = 0
   shader.attributes.color.location    = 2
   shader.attributes.uv.location       = 3
@@ -3623,7 +3647,7 @@ module.exports = createSimplicialMesh
 },{"./closest-point":9,"./shaders":11,"colormap":57,"gl-buffer":83,"gl-mat4/invert":98,"gl-mat4/multiply":100,"gl-shader":114,"gl-texture2d":123,"gl-vao":127,"ndarray":215,"normals":217,"simplicial-complex-contour":247,"typedarray-pool":264}],11:[function(require,module,exports){
 
 
-var triVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat inverse_1_0(float m) {\n  return 1.0 / m;\n}\n\nmat2 inverse_1_0(mat2 m) {\n  return mat2(m[1][1],-m[0][1],\n             -m[1][0], m[0][0]) / (m[0][0]*m[1][1] - m[0][1]*m[1][0]);\n}\n\nmat3 inverse_1_0(mat3 m) {\n  float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];\n  float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];\n  float a20 = m[2][0], a21 = m[2][1], a22 = m[2][2];\n\n  float b01 = a22 * a11 - a12 * a21;\n  float b11 = -a22 * a10 + a12 * a20;\n  float b21 = a21 * a10 - a11 * a20;\n\n  float det = a00 * b01 + a01 * b11 + a02 * b21;\n\n  return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),\n              b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),\n              b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;\n}\n\nmat4 inverse_1_0(mat4 m) {\n  float\n      a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],\n      a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],\n      a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],\n      a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],\n\n      b00 = a00 * a11 - a01 * a10,\n      b01 = a00 * a12 - a02 * a10,\n      b02 = a00 * a13 - a03 * a10,\n      b03 = a01 * a12 - a02 * a11,\n      b04 = a01 * a13 - a03 * a11,\n      b05 = a02 * a13 - a03 * a12,\n      b06 = a20 * a31 - a21 * a30,\n      b07 = a20 * a32 - a22 * a30,\n      b08 = a20 * a33 - a23 * a30,\n      b09 = a21 * a32 - a22 * a31,\n      b10 = a21 * a33 - a23 * a31,\n      b11 = a22 * a33 - a23 * a32,\n\n      det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;\n\n  return mat4(\n      a11 * b11 - a12 * b10 + a13 * b09,\n      a02 * b10 - a01 * b11 - a03 * b09,\n      a31 * b05 - a32 * b04 + a33 * b03,\n      a22 * b04 - a21 * b05 - a23 * b03,\n      a12 * b08 - a10 * b11 - a13 * b07,\n      a00 * b11 - a02 * b08 + a03 * b07,\n      a32 * b02 - a30 * b05 - a33 * b01,\n      a20 * b05 - a22 * b02 + a23 * b01,\n      a10 * b10 - a11 * b08 + a13 * b06,\n      a01 * b08 - a00 * b10 - a03 * b06,\n      a30 * b04 - a31 * b02 + a33 * b00,\n      a21 * b02 - a20 * b04 - a23 * b00,\n      a11 * b07 - a10 * b09 - a12 * b06,\n      a00 * b09 - a01 * b07 + a02 * b06,\n      a31 * b01 - a30 * b03 - a32 * b00,\n      a20 * b03 - a21 * b01 + a22 * b00) / det;\n}\n\n\n\nattribute vec3 vector;\nattribute vec4 color, position;\nattribute vec2 uv;\nuniform float vectorScale;\nuniform float coneScale;\n\nuniform mat4 model\n           , view\n           , projection;\nuniform vec3 eyePosition\n           , lightPosition;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\n\nvec3 getOrthogonalVector(vec3 v) {\n  // Return up-vector for only-z vector.\n  // Return ax + by + cz = 0, a point that lies on the plane that has v as a normal and that isn't (0,0,0).\n  // From the above if-statement we have ||a|| > 0  U  ||b|| > 0.\n  // Assign z = 0, x = -b, y = a:\n  // a*-b + b*a + c*0 = -ba + ba + 0 = 0\n  if (v.x*v.x > v.z*v.z || v.y*v.y > v.z*v.z) {\n    return normalize(vec3(-v.y, v.x, 0.0)); \n  } else {\n    return normalize(vec3(0.0, v.z, -v.y));\n  }\n}\n\n// Calculate the cone vertex and normal at the given index.\n//\n// The returned vertex is for a cone with its top at origin and height of 1.0, \n// pointing in the direction of the vector attribute.\n//\n// Each cone is made up of a top vertex, a center base vertex and base perimeter vertices.\n// These vertices are used to make up the triangles of the cone by the following:\n//   segment + 0 top vertex\n//   segment + 1 perimeter vertex a+1\n//   segment + 2 perimeter vertex a\n//   segment + 3 center base vertex\n//   segment + 4 perimeter vertex a\n//   segment + 5 perimeter vertex a+1\n// Where segment is the number of the radial segment * 6 and a is the angle at that radial segment.\n// To go from index to segment, floor(index / 6)\n// To go from segment to angle, 2*pi * (segment/segmentCount)\n// To go from index to segment index, index - (segment*6)\n//\nvec3 getConePosition(vec3 d, float index, out vec3 normal) {\n\n  const float segmentCount = 8.0;\n\n  index = mod(index, segmentCount * 6.0);\n\n  float segment = floor(index/6.0);\n  float segmentIndex = index - (segment*6.0);\n\n  normal = -normalize(d);\n\n  if (segmentIndex == 3.0) {\n    return -d;\n  }\n\n  // angle = 2pi * ((segment + ((segmentIndex == 1.0 || segmentIndex == 5.0) ? 1.0 : 0.0)) / segmentCount)\n  float nextAngle = float(segmentIndex == 1.0 || segmentIndex == 5.0);\n  float angle = 2.0 * 3.14159 * ((segment + nextAngle) / segmentCount);\n\n  vec3 v1 = vec3(0.0);\n  vec3 v2 = v1 - d;\n\n  vec3 u = getOrthogonalVector(d);\n  vec3 v = normalize(cross(u, d));\n\n  vec3 x = u * cos(angle) * length(d)*0.25;\n  vec3 y = v * sin(angle) * length(d)*0.25;\n  vec3 v3 = v2 + x + y;\n  if (segmentIndex <= 2.0) {\n    vec3 tx = u * sin(angle);\n    vec3 ty = v * -cos(angle);\n    vec3 tangent = tx + ty;\n    normal = normalize(cross(v3 - v1, tangent));\n  }\n\n  if (segmentIndex == 0.0) {\n    return vec3(0.0);\n  }\n  return v3;\n}\n\nvoid main() {\n  // Scale the vector magnitude to stay constant with\n  // model & view changes.\n  vec3 normal;\n  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, normal), 0.0);\n  normal = normalize(normal * inverse_1_0(mat3(model)));\n\n  // vec4 m_position  = model * vec4(conePosition, 1.0);\n  vec4 t_position  = view * conePosition;\n  gl_Position      = projection * t_position;\n  f_color          = color; //vec4(position.w, color.r, 0, 0);\n  f_normal         = normal;\n  f_data           = conePosition.xyz;\n  f_eyeDirection   = eyePosition   - conePosition.xyz;\n  f_lightDirection = lightPosition - conePosition.xyz;\n  f_uv             = uv;\n}"
+var triVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat inverse_1_0(float m) {\n  return 1.0 / m;\n}\n\nmat2 inverse_1_0(mat2 m) {\n  return mat2(m[1][1],-m[0][1],\n             -m[1][0], m[0][0]) / (m[0][0]*m[1][1] - m[0][1]*m[1][0]);\n}\n\nmat3 inverse_1_0(mat3 m) {\n  float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];\n  float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];\n  float a20 = m[2][0], a21 = m[2][1], a22 = m[2][2];\n\n  float b01 = a22 * a11 - a12 * a21;\n  float b11 = -a22 * a10 + a12 * a20;\n  float b21 = a21 * a10 - a11 * a20;\n\n  float det = a00 * b01 + a01 * b11 + a02 * b21;\n\n  return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),\n              b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),\n              b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;\n}\n\nmat4 inverse_1_0(mat4 m) {\n  float\n      a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],\n      a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],\n      a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],\n      a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],\n\n      b00 = a00 * a11 - a01 * a10,\n      b01 = a00 * a12 - a02 * a10,\n      b02 = a00 * a13 - a03 * a10,\n      b03 = a01 * a12 - a02 * a11,\n      b04 = a01 * a13 - a03 * a11,\n      b05 = a02 * a13 - a03 * a12,\n      b06 = a20 * a31 - a21 * a30,\n      b07 = a20 * a32 - a22 * a30,\n      b08 = a20 * a33 - a23 * a30,\n      b09 = a21 * a32 - a22 * a31,\n      b10 = a21 * a33 - a23 * a31,\n      b11 = a22 * a33 - a23 * a32,\n\n      det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;\n\n  return mat4(\n      a11 * b11 - a12 * b10 + a13 * b09,\n      a02 * b10 - a01 * b11 - a03 * b09,\n      a31 * b05 - a32 * b04 + a33 * b03,\n      a22 * b04 - a21 * b05 - a23 * b03,\n      a12 * b08 - a10 * b11 - a13 * b07,\n      a00 * b11 - a02 * b08 + a03 * b07,\n      a32 * b02 - a30 * b05 - a33 * b01,\n      a20 * b05 - a22 * b02 + a23 * b01,\n      a10 * b10 - a11 * b08 + a13 * b06,\n      a01 * b08 - a00 * b10 - a03 * b06,\n      a30 * b04 - a31 * b02 + a33 * b00,\n      a21 * b02 - a20 * b04 - a23 * b00,\n      a11 * b07 - a10 * b09 - a12 * b06,\n      a00 * b09 - a01 * b07 + a02 * b06,\n      a31 * b01 - a30 * b03 - a32 * b00,\n      a20 * b03 - a21 * b01 + a22 * b00) / det;\n}\n\n\n\nattribute vec3 vector;\nattribute vec4 color, position;\nattribute vec2 uv;\nuniform float vectorScale;\nuniform float coneScale;\n\nuniform float coneOffset;\n\nuniform mat4 model\n           , view\n           , projection;\nuniform vec3 eyePosition\n           , lightPosition;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\n\nvec3 getOrthogonalVector(vec3 v) {\n  // Return up-vector for only-z vector.\n  // Return ax + by + cz = 0, a point that lies on the plane that has v as a normal and that isn't (0,0,0).\n  // From the above if-statement we have ||a|| > 0  U  ||b|| > 0.\n  // Assign z = 0, x = -b, y = a:\n  // a*-b + b*a + c*0 = -ba + ba + 0 = 0\n  if (v.x*v.x > v.z*v.z || v.y*v.y > v.z*v.z) {\n    return normalize(vec3(-v.y, v.x, 0.0)); \n  } else {\n    return normalize(vec3(0.0, v.z, -v.y));\n  }\n}\n\n// Calculate the cone vertex and normal at the given index.\n//\n// The returned vertex is for a cone with its top at origin and height of 1.0, \n// pointing in the direction of the vector attribute.\n//\n// Each cone is made up of a top vertex, a center base vertex and base perimeter vertices.\n// These vertices are used to make up the triangles of the cone by the following:\n//   segment + 0 top vertex\n//   segment + 1 perimeter vertex a+1\n//   segment + 2 perimeter vertex a\n//   segment + 3 center base vertex\n//   segment + 4 perimeter vertex a\n//   segment + 5 perimeter vertex a+1\n// Where segment is the number of the radial segment * 6 and a is the angle at that radial segment.\n// To go from index to segment, floor(index / 6)\n// To go from segment to angle, 2*pi * (segment/segmentCount)\n// To go from index to segment index, index - (segment*6)\n//\nvec3 getConePosition(vec3 d, float index, out vec3 normal) {\n\n  const float segmentCount = 8.0;\n\n  index = mod(index, segmentCount * 6.0);\n\n  float segment = floor(index/6.0);\n  float segmentIndex = index - (segment*6.0);\n\n  normal = -normalize(d);\n\n  if (segmentIndex == 3.0) {\n    return mix(vec3(0.0), -d, coneOffset);\n  }\n\n  // angle = 2pi * ((segment + ((segmentIndex == 1.0 || segmentIndex == 5.0) ? 1.0 : 0.0)) / segmentCount)\n  float nextAngle = float(segmentIndex == 1.0 || segmentIndex == 5.0);\n  float angle = 2.0 * 3.14159 * ((segment + nextAngle) / segmentCount);\n\n  vec3 v1 = mix(d, vec3(0.0), coneOffset);\n  vec3 v2 = v1 - d;\n\n  vec3 u = getOrthogonalVector(d);\n  vec3 v = normalize(cross(u, d));\n\n  vec3 x = u * cos(angle) * length(d)*0.25;\n  vec3 y = v * sin(angle) * length(d)*0.25;\n  vec3 v3 = v2 + x + y;\n  if (segmentIndex <= 2.0) {\n    vec3 tx = u * sin(angle);\n    vec3 ty = v * -cos(angle);\n    vec3 tangent = tx + ty;\n    normal = normalize(cross(v3 - v1, tangent));\n  }\n\n  if (segmentIndex == 0.0) {\n    return mix(d, vec3(0.0), coneOffset);\n  }\n  return v3;\n}\n\nvoid main() {\n  // Scale the vector magnitude to stay constant with\n  // model & view changes.\n  vec3 normal;\n  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, normal), 0.0);\n  normal = normalize(normal * inverse_1_0(mat3(model)));\n\n  // vec4 m_position  = model * vec4(conePosition, 1.0);\n  vec4 t_position  = view * conePosition;\n  gl_Position      = projection * t_position;\n  f_color          = color; //vec4(position.w, color.r, 0, 0);\n  f_normal         = normal;\n  f_data           = conePosition.xyz;\n  f_eyeDirection   = eyePosition   - conePosition.xyz;\n  f_lightDirection = lightPosition - conePosition.xyz;\n  f_uv             = uv;\n}"
 var triFragSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat beckmannDistribution_2_0(float x, float roughness) {\n  float NdotH = max(x, 0.0001);\n  float cos2Alpha = NdotH * NdotH;\n  float tan2Alpha = (cos2Alpha - 1.0) / cos2Alpha;\n  float roughness2 = roughness * roughness;\n  float denom = 3.141592653589793 * roughness2 * cos2Alpha * cos2Alpha;\n  return exp(tan2Alpha / roughness2) / denom;\n}\n\n\n\nfloat cookTorranceSpecular_1_1(\n  vec3 lightDirection,\n  vec3 viewDirection,\n  vec3 surfaceNormal,\n  float roughness,\n  float fresnel) {\n\n  float VdotN = max(dot(viewDirection, surfaceNormal), 0.0);\n  float LdotN = max(dot(lightDirection, surfaceNormal), 0.0);\n\n  //Half angle vector\n  vec3 H = normalize(lightDirection + viewDirection);\n\n  //Geometric term\n  float NdotH = max(dot(surfaceNormal, H), 0.0);\n  float VdotH = max(dot(viewDirection, H), 0.000001);\n  float LdotH = max(dot(lightDirection, H), 0.000001);\n  float G1 = (2.0 * NdotH * VdotN) / VdotH;\n  float G2 = (2.0 * NdotH * LdotN) / LdotH;\n  float G = min(1.0, min(G1, G2));\n  \n  //Distribution term\n  float D = beckmannDistribution_2_0(NdotH, roughness);\n\n  //Fresnel term\n  float F = pow(1.0 - VdotN, fresnel);\n\n  //Multiply terms and done\n  return  G * F * D / max(3.14159265 * VdotN, 0.000001);\n}\n\n\n\nuniform vec3 clipBounds[2];\nuniform float roughness\n            , fresnel\n            , kambient\n            , kdiffuse\n            , kspecular\n            , opacity;\nuniform sampler2D texture;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\nvoid main() {\n  //if(any(lessThan(f_data, clipBounds[0])) || \n  //   any(greaterThan(f_data, clipBounds[1]))) {\n  //  discard;\n  //}\n\n  vec3 N = normalize(f_normal);\n  vec3 L = normalize(f_lightDirection);\n  vec3 V = normalize(f_eyeDirection);\n  \n  if(!gl_FrontFacing) {\n    N = -N;\n  }\n\n  float specular = cookTorranceSpecular_1_1(L, V, N, roughness, fresnel);\n  float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);\n\n  vec4 surfaceColor =  texture2D(texture, f_uv);\n  vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);\n\n  gl_FragColor = litColor * opacity;\n}"
 var pickVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nattribute vec3 position;\nattribute vec4 id;\n\nuniform mat4 model, view, projection;\n\nvarying vec3 f_position;\nvarying vec4 f_id;\n\nvoid main() {\n  gl_Position = projection * view * model * vec4(position, 1.0);\n  f_id        = id;\n  f_position  = position;\n}"
 var pickFragSrc = "precision mediump float;\n#define GLSLIFY 1\n\nuniform vec3  clipBounds[2];\nuniform float pickId;\n\nvarying vec3 f_position;\nvarying vec4 f_id;\n\nvoid main() {\n  if(any(lessThan(f_position, clipBounds[0])) || \n     any(greaterThan(f_position, clipBounds[1]))) {\n    discard;\n  }\n  gl_FragColor = vec4(pickId, f_id.xyz);\n}"

--- a/build/example_single.js
+++ b/build/example_single.js
@@ -2372,8 +2372,8 @@ var createMesh = createConePlot.createConeMesh;
 var bounds = []
 
 var conePlot = createConePlot({
-  positions: [[0.5, 0.5, 0.5], [1,1,1], [1.5, 1.5, 1.5]],
-  vectors: [[0.05, 0, 0], [0, 0.05, 0], [0, 0, 0.05]],
+  positions: [[0.5, 0.5, 0.5]],
+  vectors: [[0.05, 0, 0]],
   colormap: 'portland'
 }, bounds)
 

--- a/build/example_sparse.js
+++ b/build/example_sparse.js
@@ -2099,49 +2099,50 @@ process.umask = function() { return 0; };
 },{}],6:[function(require,module,exports){
 "use strict";
 
-const V = require('gl-vec3');
-const V4 = require('gl-vec4');
+var V = require('gl-vec3');
+var V4 = require('gl-vec4');
 
-const vec3 = function(x, y, z) {
-	let v = V.create();
+var vec3 = function(x, y, z) {
+	var v = V.create();
 	if (x !== undefined) {
 		V.set(v, x, y, z);
 	}
 	return v;
 }
 
-var createPositionsForMeshgrid = function([xs, ys, zs]) {
-  var positions = [];
-  for (var z=0; z<zs.length; z++) {
-    for (var y=0; y<ys.length; y++) {
-      for (var x=0; x<xs.length; x++) {
-        positions.push([zs[z], ys[y], xs[x]]);
-      }
-    }
-  }
-  return positions;
+var createPositionsForMeshgrid = function(meshgrid) {
+	var xs = meshgrid[0], ys = meshgrid[1], zs = meshgrid[2];
+	var positions = [];
+	for (var z=0; z<zs.length; z++) {
+		for (var y=0; y<ys.length; y++) {
+			for (var x=0; x<xs.length; x++) {
+				positions.push([zs[z], ys[y], xs[x]]);
+			}
+		}
+	}
+	return positions;
 };
 
-const findLastSmallerIndex = function(points, v) {
-  for (var i=0; i<points.length; i++) {
-    if (points[i] >= v) {
-      return i-1;
-    }
-  }
-  return i;
+var findLastSmallerIndex = function(points, v) {
+	for (var i=0; i<points.length; i++) {
+		if (points[i] >= v) {
+			return i-1;
+		}
+	}
+	return i;
 };
 
-const tmp = V.create();
-const tmp2 = V.create();
+var tmp = V.create();
+var tmp2 = V.create();
 
-const clamp = function(v, min, max) {
+var clamp = function(v, min, max) {
 	return v < min ? min : (v > max ? max : v);
 };
 
-const sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
-	const x = point[0];
-	const y = point[1];
-	const z = point[2];
+var sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
+	var x = point[0];
+	var y = point[1];
+	var z = point[2];
 
 	var w = meshgrid[0].length;
 	var h = meshgrid[1].length;
@@ -2219,7 +2220,7 @@ const sampleMeshgrid = function(point, array, meshgrid, clampOverflow) {
 	return result;
 };
 
-const getOrthogonalVector = function(dst, v) {
+var getOrthogonalVector = function(dst, v) {
 	// Return up-vector for only-z vector.
 	if (v[0] === 0 && v[1] === 0) {
 		V.set(dst, 0, 1, 0);
@@ -2242,43 +2243,45 @@ module.exports = function(vectorfield, bounds) {
 	}
 	var meshgrid = vectorfield.meshgrid;
 	var vectors = vectorfield.vectors;
-	let geo = {
+	var geo = {
 		positions: [],
 		vertexIntensity: [],
+		vertexIntensityBounds: vectorfield.vertexIntensityBounds,
 		vertexNormals: [],
 		vectors: [],
 		cells: [],
+		coneOffset: vectorfield.coneOffset,
 		colormap: vectorfield.colormap
 	};
 
 	// Compute bounding box for the dataset.
 	// Compute maximum velocity for the dataset to use for scaling the cones.
-	let maxLen = 0;
-	let minX = 1/0, maxX = -1/0;
-	let minY = 1/0, maxY = -1/0;
-	let minZ = 1/0, maxZ = -1/0;
-	let v2 = null;
-	let positionVectors = [];
-	let minSeparation = 1/0;
-	for (let i = 0; i < positions.length; i++) {
-		let v1 = positions[i];
+	var maxNorm = 0;
+	var minX = 1/0, maxX = -1/0;
+	var minY = 1/0, maxY = -1/0;
+	var minZ = 1/0, maxZ = -1/0;
+	var v2 = null;
+	var positionVectors = [];
+	var minSeparation = 1/0;
+	for (var i = 0; i < positions.length; i++) {
+		var v1 = positions[i];
 		minX = Math.min(v1[0], minX);
 		maxX = Math.max(v1[0], maxX);
 		minY = Math.min(v1[1], minY);
 		maxY = Math.max(v1[1], maxY);
 		minZ = Math.min(v1[2], minZ);
 		maxZ = Math.max(v1[2], maxZ);
-		let u;
+		var u;
 		if (meshgrid) {
 			u = sampleMeshgrid(v1, vectors, meshgrid, true);
 		} else {
 			u = vectors[i];
 		}
-		if (V.length(u) > maxLen) {
-			maxLen = V.length(u);
+		if (V.length(u) > maxNorm) {
+			maxNorm = V.length(u);
 		}
 		if (v2) {
-			let separation = V.distance(v1, v2);
+			var separation = V.distance(v1, v2);
 			if (separation < minSeparation) {
 				minSeparation = separation;
 			}
@@ -2286,33 +2289,44 @@ module.exports = function(vectorfield, bounds) {
 		v2 = v1;
 		positionVectors.push(u);
 	}
-	let minV = [minX, minY, minZ];
-	let maxV = [maxX, maxY, maxZ];
+	var minV = [minX, minY, minZ];
+	var maxV = [maxX, maxY, maxZ];
 	if (bounds) {
 		bounds[0] = minV;
 		bounds[1] = maxV;
 	}
-	let scaleV = V.subtract(vec3(), maxV, minV);
-	let imaxLen = 1 / maxLen;
+	if (maxNorm === 0) {
+		maxNorm = 1;
+	}
+	// Inverted max norm would map vector with norm maxNorm to 1 coord space units in length
+	var invertedMaxNorm = 1 / maxNorm;
 
-	geo.vectorScale = imaxLen * minSeparation;
+	if (!isFinite(minSeparation) || isNaN(minSeparation)) {
+		minSeparation = 1.0;
+	}
 
-	let nml = vec3(0,1,0);
+	// Inverted max norm multiplied scaled by smallest found vector position distance:
+	// Maps a vector with norm maxNorm to minSeparation coord space units in length.
+	// In practice, scales maxNorm vectors so that they are just long enough to reach the adjacent vector position.
+	geo.vectorScale = invertedMaxNorm * minSeparation;
 
-	let coneScale = vectorfield.coneSize || 0.5;
+	var nml = vec3(0,1,0);
+
+	var coneScale = vectorfield.coneSize || 0.5;
 
 	if (vectorfield.absoluteConeSize) {
-		coneScale = vectorfield.absoluteConeSize * imaxLen;
+		coneScale = vectorfield.absoluteConeSize * invertedMaxNorm;
 	}
 
 	geo.coneScale = coneScale;
 
 	// Build the cone model.
-	for (let i = 0, j = 0; i < positions.length; i++) {
-		let [x,y,z] = positions[i];
-		let d = positionVectors[i];
-		let intensity = V.length(d) * imaxLen;
-		for (let k = 0, l = 8; k < l; k++) {
+	for (var i = 0, j = 0; i < positions.length; i++) {
+		var p = positions[i];
+		var x = p[0], y = p[1], z = p[2];
+		var d = positionVectors[i];
+		var intensity = V.length(d) * invertedMaxNorm;
+		for (var k = 0, l = 8; k < l; k++) {
 			geo.positions.push([x, y, z, j++]);
 			geo.positions.push([x, y, z, j++]);
 			geo.positions.push([x, y, z, j++]);
@@ -2333,7 +2347,7 @@ module.exports = function(vectorfield, bounds) {
 			geo.vertexNormals.push(nml, nml, nml);
 			geo.vertexNormals.push(nml, nml, nml);
 
-			let m = geo.positions.length;
+			var m = geo.positions.length;
 			geo.cells.push([m-6, m-5, m-4], [m-3, m-2, m-1]);
 		}
 	}
@@ -2342,6 +2356,7 @@ module.exports = function(vectorfield, bounds) {
 };
 
 module.exports.createConeMesh = require('./lib/conemesh');
+
 },{"./lib/conemesh":10,"gl-vec3":132,"gl-vec4":162}],7:[function(require,module,exports){
 var createCamera = require('3d-view-controls')
 var getBounds    = require('bound-points')
@@ -2401,7 +2416,7 @@ window.addEventListener('resize', require('canvas-fit')(canvas))
 var gl = canvas.getContext('webgl')
 
 var camera = createCamera(canvas, {
-  eye:    bounds[0],
+  eye:    [100,100,100],
   center: [0.5*(bounds[0][0]+bounds[1][0]),
            0.5*(bounds[0][1]+bounds[1][1]),
            0.5*(bounds[0][2]+bounds[1][2])],
@@ -2414,7 +2429,7 @@ var mesh = createMesh(gl, conePlot)
 
 var select = createSelect(gl, [canvas.width, canvas.height])
 var tickSpacing = 5;
-var ticks = bounds[0].map((v,i) => {
+var ticks = bounds[0].map(function(v,i) {
   var arr = [];
   var firstTick = Math.ceil(bounds[0][i] / tickSpacing) * tickSpacing;
   var lastTick = Math.floor(bounds[1][i] / tickSpacing) * tickSpacing;
@@ -2700,6 +2715,7 @@ function SimplicialMesh(gl
 
   this.coneScale     = 2.0
   this.vectorScale   = 1.0
+  this.coneOffset    = 1.0 / 4.0;
 
   this._model       = identityMatrix
   this._view        = identityMatrix
@@ -2838,6 +2854,16 @@ proto.update = function(params) {
     this.fresnel = params.fresnel
   }
 
+  if (params.vectorScale !== undefined) {
+    this.vectorScale = params.vectorScale;
+  }
+  if (params.coneScale !== undefined) {
+    this.coneScale = params.coneScale;
+  }
+  if (params.coneOffset !== undefined) {
+    this.coneOffset = params.coneOffset;
+  }
+
   if(params.texture) {
     this.texture.dispose()
     this.texture = createTexture(gl, params.texture)
@@ -2855,13 +2881,6 @@ proto.update = function(params) {
 
   if(!positions || !cells || !vectors) {
     return
-  }
-
-  if (params.vectorScale) {
-    this.vectorScale = params.vectorScale;
-  }
-  if (params.coneScale) {
-    this.coneScale = params.coneScale;
   }
 
   var tPos = []
@@ -3218,6 +3237,7 @@ proto.drawTransparent = proto.draw = function(params) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     contourColor: this.contourColor,
 
@@ -3318,6 +3338,7 @@ proto.drawPick = function(params) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     pickId:     this.pickId / 255.0,
   }
@@ -3395,6 +3416,7 @@ proto.pick = function(pickData) {
 
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
+    coneOffset: this.coneOffset,
 
     dataCoordinate: this.positions[cell[data[0]]]
   }
@@ -3437,7 +3459,9 @@ proto.dispose = function() {
 }
 
 function createMeshShader(gl) {
-  var shader = createShader(gl, meshShader.vertex, meshShader.fragment)
+  // need to pass meshShader attributes manually,
+  // to make this work on etpinard's Ubuntu Thinkpad
+  var shader = createShader(gl, meshShader.vertex, meshShader.fragment, null, meshShader.attributes)
   shader.attributes.position.location = 0
   shader.attributes.color.location    = 2
   shader.attributes.uv.location       = 3
@@ -3635,7 +3659,7 @@ module.exports = createSimplicialMesh
 },{"./closest-point":9,"./shaders":11,"colormap":57,"gl-buffer":83,"gl-mat4/invert":94,"gl-mat4/multiply":96,"gl-shader":107,"gl-texture2d":116,"gl-vao":120,"ndarray":208,"normals":210,"simplicial-complex-contour":240,"typedarray-pool":257}],11:[function(require,module,exports){
 
 
-var triVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat inverse_1_0(float m) {\n  return 1.0 / m;\n}\n\nmat2 inverse_1_0(mat2 m) {\n  return mat2(m[1][1],-m[0][1],\n             -m[1][0], m[0][0]) / (m[0][0]*m[1][1] - m[0][1]*m[1][0]);\n}\n\nmat3 inverse_1_0(mat3 m) {\n  float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];\n  float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];\n  float a20 = m[2][0], a21 = m[2][1], a22 = m[2][2];\n\n  float b01 = a22 * a11 - a12 * a21;\n  float b11 = -a22 * a10 + a12 * a20;\n  float b21 = a21 * a10 - a11 * a20;\n\n  float det = a00 * b01 + a01 * b11 + a02 * b21;\n\n  return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),\n              b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),\n              b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;\n}\n\nmat4 inverse_1_0(mat4 m) {\n  float\n      a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],\n      a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],\n      a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],\n      a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],\n\n      b00 = a00 * a11 - a01 * a10,\n      b01 = a00 * a12 - a02 * a10,\n      b02 = a00 * a13 - a03 * a10,\n      b03 = a01 * a12 - a02 * a11,\n      b04 = a01 * a13 - a03 * a11,\n      b05 = a02 * a13 - a03 * a12,\n      b06 = a20 * a31 - a21 * a30,\n      b07 = a20 * a32 - a22 * a30,\n      b08 = a20 * a33 - a23 * a30,\n      b09 = a21 * a32 - a22 * a31,\n      b10 = a21 * a33 - a23 * a31,\n      b11 = a22 * a33 - a23 * a32,\n\n      det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;\n\n  return mat4(\n      a11 * b11 - a12 * b10 + a13 * b09,\n      a02 * b10 - a01 * b11 - a03 * b09,\n      a31 * b05 - a32 * b04 + a33 * b03,\n      a22 * b04 - a21 * b05 - a23 * b03,\n      a12 * b08 - a10 * b11 - a13 * b07,\n      a00 * b11 - a02 * b08 + a03 * b07,\n      a32 * b02 - a30 * b05 - a33 * b01,\n      a20 * b05 - a22 * b02 + a23 * b01,\n      a10 * b10 - a11 * b08 + a13 * b06,\n      a01 * b08 - a00 * b10 - a03 * b06,\n      a30 * b04 - a31 * b02 + a33 * b00,\n      a21 * b02 - a20 * b04 - a23 * b00,\n      a11 * b07 - a10 * b09 - a12 * b06,\n      a00 * b09 - a01 * b07 + a02 * b06,\n      a31 * b01 - a30 * b03 - a32 * b00,\n      a20 * b03 - a21 * b01 + a22 * b00) / det;\n}\n\n\n\nattribute vec3 vector;\nattribute vec4 color, position;\nattribute vec2 uv;\nuniform float vectorScale;\nuniform float coneScale;\n\nuniform mat4 model\n           , view\n           , projection;\nuniform vec3 eyePosition\n           , lightPosition;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\n\nvec3 getOrthogonalVector(vec3 v) {\n  // Return up-vector for only-z vector.\n  // Return ax + by + cz = 0, a point that lies on the plane that has v as a normal and that isn't (0,0,0).\n  // From the above if-statement we have ||a|| > 0  U  ||b|| > 0.\n  // Assign z = 0, x = -b, y = a:\n  // a*-b + b*a + c*0 = -ba + ba + 0 = 0\n  if (v.x*v.x > v.z*v.z || v.y*v.y > v.z*v.z) {\n    return normalize(vec3(-v.y, v.x, 0.0)); \n  } else {\n    return normalize(vec3(0.0, v.z, -v.y));\n  }\n}\n\n// Calculate the cone vertex and normal at the given index.\n//\n// The returned vertex is for a cone with its top at origin and height of 1.0, \n// pointing in the direction of the vector attribute.\n//\n// Each cone is made up of a top vertex, a center base vertex and base perimeter vertices.\n// These vertices are used to make up the triangles of the cone by the following:\n//   segment + 0 top vertex\n//   segment + 1 perimeter vertex a+1\n//   segment + 2 perimeter vertex a\n//   segment + 3 center base vertex\n//   segment + 4 perimeter vertex a\n//   segment + 5 perimeter vertex a+1\n// Where segment is the number of the radial segment * 6 and a is the angle at that radial segment.\n// To go from index to segment, floor(index / 6)\n// To go from segment to angle, 2*pi * (segment/segmentCount)\n// To go from index to segment index, index - (segment*6)\n//\nvec3 getConePosition(vec3 d, float index, out vec3 normal) {\n\n  const float segmentCount = 8.0;\n\n  index = mod(index, segmentCount * 6.0);\n\n  float segment = floor(index/6.0);\n  float segmentIndex = index - (segment*6.0);\n\n  normal = -normalize(d);\n\n  if (segmentIndex == 3.0) {\n    return -d;\n  }\n\n  // angle = 2pi * ((segment + ((segmentIndex == 1.0 || segmentIndex == 5.0) ? 1.0 : 0.0)) / segmentCount)\n  float nextAngle = float(segmentIndex == 1.0 || segmentIndex == 5.0);\n  float angle = 2.0 * 3.14159 * ((segment + nextAngle) / segmentCount);\n\n  vec3 v1 = vec3(0.0);\n  vec3 v2 = v1 - d;\n\n  vec3 u = getOrthogonalVector(d);\n  vec3 v = normalize(cross(u, d));\n\n  vec3 x = u * cos(angle) * length(d)*0.25;\n  vec3 y = v * sin(angle) * length(d)*0.25;\n  vec3 v3 = v2 + x + y;\n  if (segmentIndex <= 2.0) {\n    vec3 tx = u * sin(angle);\n    vec3 ty = v * -cos(angle);\n    vec3 tangent = tx + ty;\n    normal = normalize(cross(v3 - v1, tangent));\n  }\n\n  if (segmentIndex == 0.0) {\n    return vec3(0.0);\n  }\n  return v3;\n}\n\nvoid main() {\n  // Scale the vector magnitude to stay constant with\n  // model & view changes.\n  vec3 normal;\n  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, normal), 0.0);\n  normal = normalize(normal * inverse_1_0(mat3(model)));\n\n  // vec4 m_position  = model * vec4(conePosition, 1.0);\n  vec4 t_position  = view * conePosition;\n  gl_Position      = projection * t_position;\n  f_color          = color; //vec4(position.w, color.r, 0, 0);\n  f_normal         = normal;\n  f_data           = conePosition.xyz;\n  f_eyeDirection   = eyePosition   - conePosition.xyz;\n  f_lightDirection = lightPosition - conePosition.xyz;\n  f_uv             = uv;\n}"
+var triVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat inverse_1_0(float m) {\n  return 1.0 / m;\n}\n\nmat2 inverse_1_0(mat2 m) {\n  return mat2(m[1][1],-m[0][1],\n             -m[1][0], m[0][0]) / (m[0][0]*m[1][1] - m[0][1]*m[1][0]);\n}\n\nmat3 inverse_1_0(mat3 m) {\n  float a00 = m[0][0], a01 = m[0][1], a02 = m[0][2];\n  float a10 = m[1][0], a11 = m[1][1], a12 = m[1][2];\n  float a20 = m[2][0], a21 = m[2][1], a22 = m[2][2];\n\n  float b01 = a22 * a11 - a12 * a21;\n  float b11 = -a22 * a10 + a12 * a20;\n  float b21 = a21 * a10 - a11 * a20;\n\n  float det = a00 * b01 + a01 * b11 + a02 * b21;\n\n  return mat3(b01, (-a22 * a01 + a02 * a21), (a12 * a01 - a02 * a11),\n              b11, (a22 * a00 - a02 * a20), (-a12 * a00 + a02 * a10),\n              b21, (-a21 * a00 + a01 * a20), (a11 * a00 - a01 * a10)) / det;\n}\n\nmat4 inverse_1_0(mat4 m) {\n  float\n      a00 = m[0][0], a01 = m[0][1], a02 = m[0][2], a03 = m[0][3],\n      a10 = m[1][0], a11 = m[1][1], a12 = m[1][2], a13 = m[1][3],\n      a20 = m[2][0], a21 = m[2][1], a22 = m[2][2], a23 = m[2][3],\n      a30 = m[3][0], a31 = m[3][1], a32 = m[3][2], a33 = m[3][3],\n\n      b00 = a00 * a11 - a01 * a10,\n      b01 = a00 * a12 - a02 * a10,\n      b02 = a00 * a13 - a03 * a10,\n      b03 = a01 * a12 - a02 * a11,\n      b04 = a01 * a13 - a03 * a11,\n      b05 = a02 * a13 - a03 * a12,\n      b06 = a20 * a31 - a21 * a30,\n      b07 = a20 * a32 - a22 * a30,\n      b08 = a20 * a33 - a23 * a30,\n      b09 = a21 * a32 - a22 * a31,\n      b10 = a21 * a33 - a23 * a31,\n      b11 = a22 * a33 - a23 * a32,\n\n      det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;\n\n  return mat4(\n      a11 * b11 - a12 * b10 + a13 * b09,\n      a02 * b10 - a01 * b11 - a03 * b09,\n      a31 * b05 - a32 * b04 + a33 * b03,\n      a22 * b04 - a21 * b05 - a23 * b03,\n      a12 * b08 - a10 * b11 - a13 * b07,\n      a00 * b11 - a02 * b08 + a03 * b07,\n      a32 * b02 - a30 * b05 - a33 * b01,\n      a20 * b05 - a22 * b02 + a23 * b01,\n      a10 * b10 - a11 * b08 + a13 * b06,\n      a01 * b08 - a00 * b10 - a03 * b06,\n      a30 * b04 - a31 * b02 + a33 * b00,\n      a21 * b02 - a20 * b04 - a23 * b00,\n      a11 * b07 - a10 * b09 - a12 * b06,\n      a00 * b09 - a01 * b07 + a02 * b06,\n      a31 * b01 - a30 * b03 - a32 * b00,\n      a20 * b03 - a21 * b01 + a22 * b00) / det;\n}\n\n\n\nattribute vec3 vector;\nattribute vec4 color, position;\nattribute vec2 uv;\nuniform float vectorScale;\nuniform float coneScale;\n\nuniform float coneOffset;\n\nuniform mat4 model\n           , view\n           , projection;\nuniform vec3 eyePosition\n           , lightPosition;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\n\nvec3 getOrthogonalVector(vec3 v) {\n  // Return up-vector for only-z vector.\n  // Return ax + by + cz = 0, a point that lies on the plane that has v as a normal and that isn't (0,0,0).\n  // From the above if-statement we have ||a|| > 0  U  ||b|| > 0.\n  // Assign z = 0, x = -b, y = a:\n  // a*-b + b*a + c*0 = -ba + ba + 0 = 0\n  if (v.x*v.x > v.z*v.z || v.y*v.y > v.z*v.z) {\n    return normalize(vec3(-v.y, v.x, 0.0)); \n  } else {\n    return normalize(vec3(0.0, v.z, -v.y));\n  }\n}\n\n// Calculate the cone vertex and normal at the given index.\n//\n// The returned vertex is for a cone with its top at origin and height of 1.0, \n// pointing in the direction of the vector attribute.\n//\n// Each cone is made up of a top vertex, a center base vertex and base perimeter vertices.\n// These vertices are used to make up the triangles of the cone by the following:\n//   segment + 0 top vertex\n//   segment + 1 perimeter vertex a+1\n//   segment + 2 perimeter vertex a\n//   segment + 3 center base vertex\n//   segment + 4 perimeter vertex a\n//   segment + 5 perimeter vertex a+1\n// Where segment is the number of the radial segment * 6 and a is the angle at that radial segment.\n// To go from index to segment, floor(index / 6)\n// To go from segment to angle, 2*pi * (segment/segmentCount)\n// To go from index to segment index, index - (segment*6)\n//\nvec3 getConePosition(vec3 d, float index, out vec3 normal) {\n\n  const float segmentCount = 8.0;\n\n  index = mod(index, segmentCount * 6.0);\n\n  float segment = floor(index/6.0);\n  float segmentIndex = index - (segment*6.0);\n\n  normal = -normalize(d);\n\n  if (segmentIndex == 3.0) {\n    return mix(vec3(0.0), -d, coneOffset);\n  }\n\n  // angle = 2pi * ((segment + ((segmentIndex == 1.0 || segmentIndex == 5.0) ? 1.0 : 0.0)) / segmentCount)\n  float nextAngle = float(segmentIndex == 1.0 || segmentIndex == 5.0);\n  float angle = 2.0 * 3.14159 * ((segment + nextAngle) / segmentCount);\n\n  vec3 v1 = mix(d, vec3(0.0), coneOffset);\n  vec3 v2 = v1 - d;\n\n  vec3 u = getOrthogonalVector(d);\n  vec3 v = normalize(cross(u, d));\n\n  vec3 x = u * cos(angle) * length(d)*0.25;\n  vec3 y = v * sin(angle) * length(d)*0.25;\n  vec3 v3 = v2 + x + y;\n  if (segmentIndex <= 2.0) {\n    vec3 tx = u * sin(angle);\n    vec3 ty = v * -cos(angle);\n    vec3 tangent = tx + ty;\n    normal = normalize(cross(v3 - v1, tangent));\n  }\n\n  if (segmentIndex == 0.0) {\n    return mix(d, vec3(0.0), coneOffset);\n  }\n  return v3;\n}\n\nvoid main() {\n  // Scale the vector magnitude to stay constant with\n  // model & view changes.\n  vec3 normal;\n  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, normal), 0.0);\n  normal = normalize(normal * inverse_1_0(mat3(model)));\n\n  // vec4 m_position  = model * vec4(conePosition, 1.0);\n  vec4 t_position  = view * conePosition;\n  gl_Position      = projection * t_position;\n  f_color          = color; //vec4(position.w, color.r, 0, 0);\n  f_normal         = normal;\n  f_data           = conePosition.xyz;\n  f_eyeDirection   = eyePosition   - conePosition.xyz;\n  f_lightDirection = lightPosition - conePosition.xyz;\n  f_uv             = uv;\n}"
 var triFragSrc = "precision mediump float;\n#define GLSLIFY 1\n\nfloat beckmannDistribution_2_0(float x, float roughness) {\n  float NdotH = max(x, 0.0001);\n  float cos2Alpha = NdotH * NdotH;\n  float tan2Alpha = (cos2Alpha - 1.0) / cos2Alpha;\n  float roughness2 = roughness * roughness;\n  float denom = 3.141592653589793 * roughness2 * cos2Alpha * cos2Alpha;\n  return exp(tan2Alpha / roughness2) / denom;\n}\n\n\n\nfloat cookTorranceSpecular_1_1(\n  vec3 lightDirection,\n  vec3 viewDirection,\n  vec3 surfaceNormal,\n  float roughness,\n  float fresnel) {\n\n  float VdotN = max(dot(viewDirection, surfaceNormal), 0.0);\n  float LdotN = max(dot(lightDirection, surfaceNormal), 0.0);\n\n  //Half angle vector\n  vec3 H = normalize(lightDirection + viewDirection);\n\n  //Geometric term\n  float NdotH = max(dot(surfaceNormal, H), 0.0);\n  float VdotH = max(dot(viewDirection, H), 0.000001);\n  float LdotH = max(dot(lightDirection, H), 0.000001);\n  float G1 = (2.0 * NdotH * VdotN) / VdotH;\n  float G2 = (2.0 * NdotH * LdotN) / LdotH;\n  float G = min(1.0, min(G1, G2));\n  \n  //Distribution term\n  float D = beckmannDistribution_2_0(NdotH, roughness);\n\n  //Fresnel term\n  float F = pow(1.0 - VdotN, fresnel);\n\n  //Multiply terms and done\n  return  G * F * D / max(3.14159265 * VdotN, 0.000001);\n}\n\n\n\nuniform vec3 clipBounds[2];\nuniform float roughness\n            , fresnel\n            , kambient\n            , kdiffuse\n            , kspecular\n            , opacity;\nuniform sampler2D texture;\n\nvarying vec3 f_normal\n           , f_lightDirection\n           , f_eyeDirection\n           , f_data;\nvarying vec4 f_color;\nvarying vec2 f_uv;\n\nvoid main() {\n  //if(any(lessThan(f_data, clipBounds[0])) || \n  //   any(greaterThan(f_data, clipBounds[1]))) {\n  //  discard;\n  //}\n\n  vec3 N = normalize(f_normal);\n  vec3 L = normalize(f_lightDirection);\n  vec3 V = normalize(f_eyeDirection);\n  \n  if(!gl_FrontFacing) {\n    N = -N;\n  }\n\n  float specular = cookTorranceSpecular_1_1(L, V, N, roughness, fresnel);\n  float diffuse  = min(kambient + kdiffuse * max(dot(N, L), 0.0), 1.0);\n\n  vec4 surfaceColor =  texture2D(texture, f_uv);\n  vec4 litColor = surfaceColor.a * vec4(diffuse * surfaceColor.rgb + kspecular * vec3(1,1,1) * specular,  1.0);\n\n  gl_FragColor = litColor * opacity;\n}"
 var pickVertSrc = "precision mediump float;\n#define GLSLIFY 1\n\nattribute vec3 position;\nattribute vec4 id;\n\nuniform mat4 model, view, projection;\n\nvarying vec3 f_position;\nvarying vec4 f_id;\n\nvoid main() {\n  gl_Position = projection * view * model * vec4(position, 1.0);\n  f_id        = id;\n  f_position  = position;\n}"
 var pickFragSrc = "precision mediump float;\n#define GLSLIFY 1\n\nuniform vec3  clipBounds[2];\nuniform float pickId;\n\nvarying vec3 f_position;\nvarying vec4 f_id;\n\nvoid main() {\n  if(any(lessThan(f_position, clipBounds[0])) || \n     any(greaterThan(f_position, clipBounds[1]))) {\n    discard;\n  }\n  gl_FragColor = vec4(pickId, f_id.xyz);\n}"

--- a/example/cone.js
+++ b/example/cone.js
@@ -44,7 +44,7 @@ var mesh = createMesh(gl, conePlot)
 
 var select = createSelect(gl, [canvas.width, canvas.height])
 var tickSpacing = 5;
-var ticks = bounds[0].map((v,i) => {
+var ticks = bounds[0].map(function(v,i) {
   var arr = [];
   var firstTick = Math.ceil(bounds[0][i] / tickSpacing) * tickSpacing;
   var lastTick = Math.floor(bounds[1][i] / tickSpacing) * tickSpacing;

--- a/example/cone_minimal.js
+++ b/example/cone_minimal.js
@@ -34,7 +34,7 @@ var mesh = createMesh(gl, conePlot)
 
 var select = createSelect(gl, [canvas.width, canvas.height])
 var tickSpacing = 1;
-var ticks = bounds[0].map((v,i) => {
+var ticks = bounds[0].map(function(v,i) {
   var arr = [];
   var firstTick = 0; //Math.ceil(bounds[0][i] / tickSpacing) * tickSpacing;
   var lastTick = 3; //Math.floor(bounds[1][i] / tickSpacing) * tickSpacing;

--- a/example/cone_sparse.js
+++ b/example/cone_sparse.js
@@ -56,7 +56,7 @@ window.addEventListener('resize', require('canvas-fit')(canvas))
 var gl = canvas.getContext('webgl')
 
 var camera = createCamera(canvas, {
-  eye:    bounds[0],
+  eye:    [100,100,100],
   center: [0.5*(bounds[0][0]+bounds[1][0]),
            0.5*(bounds[0][1]+bounds[1][1]),
            0.5*(bounds[0][2]+bounds[1][2])],

--- a/example/cone_sparse.js
+++ b/example/cone_sparse.js
@@ -69,7 +69,7 @@ var mesh = createMesh(gl, conePlot)
 
 var select = createSelect(gl, [canvas.width, canvas.height])
 var tickSpacing = 5;
-var ticks = bounds[0].map((v,i) => {
+var ticks = bounds[0].map(function(v,i) {
   var arr = [];
   var firstTick = Math.ceil(bounds[0][i] / tickSpacing) * tickSpacing;
   var lastTick = Math.floor(bounds[1][i] / tickSpacing) * tickSpacing;


### PR DESCRIPTION
Moves sparse example camera outside the dataset so that its view is not blocked by cones.
Changes some .map((x) => calls to .map(function(x) { in the examples.