### PR TITLE
Rev bounds

### DIFF
--- a/lib/pick-fragment.glsl
+++ b/lib/pick-fragment.glsl
@@ -13,9 +13,9 @@ bool outOfRange(float a, float b, float p) {
 }
 
 void main() {
-  if (outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) discard;
-  if (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) discard;
-  if (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z)) discard;
+  if ((outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) ||
+      (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) ||
+      (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z))) discard;
 
   gl_FragColor = vec4(pickId, f_id.xyz);
 }

--- a/lib/pick-fragment.glsl
+++ b/lib/pick-fragment.glsl
@@ -1,16 +1,12 @@
 precision mediump float;
 
+#pragma glslify: outOfRange = require(./reversed-scenes-out-of-range.glsl)
+
 uniform vec3  clipBounds[2];
 uniform float pickId;
 
 varying vec3 f_position;
 varying vec4 f_id;
-
-bool outOfRange(float a, float b, float p) {
-  if (p > max(a, b)) return true;
-  if (p < min(a, b)) return true;
-  return false;
-}
 
 void main() {
   if ((outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) ||

--- a/lib/pick-fragment.glsl
+++ b/lib/pick-fragment.glsl
@@ -6,10 +6,16 @@ uniform float pickId;
 varying vec3 f_position;
 varying vec4 f_id;
 
+bool outOfRange(float a, float b, float p) {
+  if (p > max(a, b)) return true;
+  if (p < min(a, b)) return true;
+  return false;
+}
+
 void main() {
-  if(any(lessThan(f_position, clipBounds[0])) || 
-     any(greaterThan(f_position, clipBounds[1]))) {
-    discard;
-  }
+  if (outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) discard;
+  if (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) discard;
+  if (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z)) discard;
+
   gl_FragColor = vec4(pickId, f_id.xyz);
 }

--- a/lib/pick-fragment.glsl
+++ b/lib/pick-fragment.glsl
@@ -1,6 +1,6 @@
 precision mediump float;
 
-#pragma glslify: outOfRange = require(./reversed-scenes-out-of-range.glsl)
+#pragma glslify: outOfRange = require(glsl-out-of-range)
 
 uniform vec3  clipBounds[2];
 uniform float pickId;
@@ -9,9 +9,7 @@ varying vec3 f_position;
 varying vec4 f_id;
 
 void main() {
-  if ((outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) ||
-      (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) ||
-      (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z))) discard;
+  if (outOfRange(clipBounds[0], clipBounds[1], f_position)) discard;
 
   gl_FragColor = vec4(pickId, f_id.xyz);
 }

--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -18,7 +18,7 @@ varying vec4 f_id;
 void main() {
   vec3 normal;
   vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal);
-  vec4 conePosition = model * vec4(position.xyz + XYZ, 1.0);
+  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(XYZ, 0.0);
   gl_Position = projection * view * conePosition;
   f_id        = id;
   f_position  = position.xyz;

--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -17,7 +17,8 @@ varying vec4 f_id;
 
 void main() {
   vec3 normal;
-  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal), 0.0);
+  vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal);
+  vec4 conePosition = model * vec4(position.xyz + XYZ, 1.0);
   gl_Position = projection * view * conePosition;
   f_id        = id;
   f_position  = position.xyz;

--- a/lib/reversed-scenes-out-of-range.glsl
+++ b/lib/reversed-scenes-out-of-range.glsl
@@ -1,0 +1,7 @@
+bool outOfRange(float a, float b, float p) {
+  if (p > max(a, b)) return true;
+  if (p < min(a, b)) return true;
+  return false;
+}
+
+#pragma glslify: export(outOfRange)

--- a/lib/reversed-scenes-out-of-range.glsl
+++ b/lib/reversed-scenes-out-of-range.glsl
@@ -1,7 +1,0 @@
-bool outOfRange(float a, float b, float p) {
-  if (p > max(a, b)) return true;
-  if (p < min(a, b)) return true;
-  return false;
-}
-
-#pragma glslify: export(outOfRange)

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -1,6 +1,7 @@
 precision mediump float;
 
 #pragma glslify: cookTorrance = require(glsl-specular-cook-torrance)
+#pragma glslify: outOfRange = require(./reversed-scenes-out-of-range.glsl)
 
 uniform vec3 clipBounds[2];
 uniform float roughness
@@ -14,15 +15,21 @@ uniform sampler2D texture;
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data;
+           , f_data
+           , f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
 void main() {
+
+  if ((outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) ||
+      (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) ||
+      (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z))) discard;
+
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);
   vec3 V = normalize(f_eyeDirection);
-  
+
   if(!gl_FrontFacing) {
     N = -N;
   }

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -18,11 +18,16 @@ varying vec3 f_normal
 varying vec4 f_color;
 varying vec2 f_uv;
 
+bool outOfRange(float a, float b, float p) {
+  if (p > max(a, b)) return true;
+  if (p < min(a, b)) return true;
+  return false;
+}
+
 void main() {
-  //if(any(lessThan(f_data, clipBounds[0])) || 
-  //   any(greaterThan(f_data, clipBounds[1]))) {
-  //  discard;
-  //}
+  //if (outOfRange(clipBounds[0].x, clipBounds[1].x, f_data.x)) discard;
+  //if (outOfRange(clipBounds[0].y, clipBounds[1].y, f_data.y)) discard;
+  //if (outOfRange(clipBounds[0].z, clipBounds[1].z, f_data.z)) discard;
 
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -18,17 +18,7 @@ varying vec3 f_normal
 varying vec4 f_color;
 varying vec2 f_uv;
 
-bool outOfRange(float a, float b, float p) {
-  if (p > max(a, b)) return true;
-  if (p < min(a, b)) return true;
-  return false;
-}
-
 void main() {
-  //if (outOfRange(clipBounds[0].x, clipBounds[1].x, f_data.x)) discard;
-  //if (outOfRange(clipBounds[0].y, clipBounds[1].y, f_data.y)) discard;
-  //if (outOfRange(clipBounds[0].z, clipBounds[1].z, f_data.z)) discard;
-
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);
   vec3 V = normalize(f_eyeDirection);

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -1,7 +1,7 @@
 precision mediump float;
 
 #pragma glslify: cookTorrance = require(glsl-specular-cook-torrance)
-#pragma glslify: outOfRange = require(./reversed-scenes-out-of-range.glsl)
+#pragma glslify: outOfRange = require(glsl-out-of-range)
 
 uniform vec3 clipBounds[2];
 uniform float roughness
@@ -22,9 +22,7 @@ varying vec2 f_uv;
 
 void main() {
 
-  if ((outOfRange(clipBounds[0].x, clipBounds[1].x, f_position.x)) ||
-      (outOfRange(clipBounds[0].y, clipBounds[1].y, f_position.y)) ||
-      (outOfRange(clipBounds[0].z, clipBounds[1].z, f_position.z))) discard;
+  if (outOfRange(clipBounds[0], clipBounds[1], f_position)) discard;
 
   vec3 N = normalize(f_normal);
   vec3 L = normalize(f_lightDirection);

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -30,7 +30,7 @@ void main() {
   // model & view changes.
   vec3 normal;
   vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal);
-  vec4 conePosition = model * vec4(position.xyz + XYZ, 1.0);
+  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(XYZ, 0.0);
   normal = normalize(normal * inverse(mat3(model)));
 
   // vec4 m_position  = model * vec4(conePosition, 1.0);

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -20,7 +20,8 @@ uniform vec3 eyePosition
 varying vec3 f_normal
            , f_lightDirection
            , f_eyeDirection
-           , f_data;
+           , f_data
+           , f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -28,7 +29,8 @@ void main() {
   // Scale the vector magnitude to stay constant with
   // model & view changes.
   vec3 normal;
-  vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal), 0.0);
+  vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal);
+  vec4 conePosition = model * vec4(position.xyz + XYZ, 1.0);
   normal = normalize(normal * inverse(mat3(model)));
 
   // vec4 m_position  = model * vec4(conePosition, 1.0);
@@ -37,6 +39,7 @@ void main() {
   f_color          = color; //vec4(position.w, color.r, 0, 0);
   f_normal         = normal;
   f_data           = conePosition.xyz;
+  f_position       = position.xyz;
   f_eyeDirection   = eyePosition   - conePosition.xyz;
   f_lightDirection = lightPosition - conePosition.xyz;
   f_uv             = uv;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
       "dev": true,
       "requires": {
-        "matrix-camera-controller": "2.1.3",
-        "orbit-camera-controller": "4.0.0",
-        "turntable-camera-controller": "3.0.1"
+        "matrix-camera-controller": "^2.1.1",
+        "orbit-camera-controller": "^4.0.0",
+        "turntable-camera-controller": "^3.0.0"
       }
     },
     "3d-view-controls": {
@@ -21,12 +21,12 @@
       "integrity": "sha512-WL0u3PN41lEx/4qvKqV6bJlweUYoW18FXMshW/qHb41AVdZxDReLoJNGYsI7x6jf9bYelEF62BJPQmO7yEnG2w==",
       "dev": true,
       "requires": {
-        "3d-view": "2.0.0",
-        "has-passive-events": "1.0.0",
-        "mouse-change": "1.4.0",
-        "mouse-event-offset": "3.0.2",
-        "mouse-wheel": "1.2.0",
-        "right-now": "1.0.0"
+        "3d-view": "^2.0.0",
+        "has-passive-events": "^1.0.0",
+        "mouse-change": "^1.1.1",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.0.2",
+        "right-now": "^1.0.0"
       }
     },
     "acorn": {
@@ -39,7 +39,7 @@
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
       "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
       "requires": {
-        "pad-left": "1.0.2"
+        "pad-left": "^1.0.2"
       }
     },
     "affine-hull": {
@@ -48,7 +48,7 @@
       "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "align-text": {
@@ -57,9 +57,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -85,7 +85,7 @@
       "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
       "dev": true,
       "requires": {
-        "robust-linear-solve": "1.0.0"
+        "robust-linear-solve": "^1.0.0"
       }
     },
     "big-rat": {
@@ -94,9 +94,9 @@
       "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
       "dev": true,
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "bn.js": "4.11.8",
-        "double-bits": "1.1.1"
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
       }
     },
     "binary-search-bounds": {
@@ -116,7 +116,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.5"
       }
     },
     "bn.js": {
@@ -137,8 +137,8 @@
       "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
       "dev": true,
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "typedarray-pool": "1.1.0"
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "brace-expansion": {
@@ -146,7 +146,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -162,7 +162,7 @@
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
       "dev": true,
       "requires": {
-        "element-size": "1.1.1"
+        "element-size": "^1.1.1"
       }
     },
     "cdt2d": {
@@ -171,9 +171,9 @@
       "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "robust-in-sphere": "1.1.3",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -190,8 +190,8 @@
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "clean-pslg": {
@@ -200,13 +200,13 @@
       "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
       "dev": true,
       "requires": {
-        "big-rat": "1.0.4",
-        "box-intersect": "1.0.1",
-        "nextafter": "1.0.0",
-        "rat-vec": "1.1.1",
-        "robust-segment-intersect": "1.0.1",
-        "union-find": "1.0.2",
-        "uniq": "1.0.1"
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
       }
     },
     "cliui": {
@@ -215,8 +215,8 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -234,7 +234,7 @@
       "integrity": "sha512-Mkk6mQUMbCleXEeStFm2xLwv5zbRakZMUFB1T1+iNEv58VKBByfPwYIjMQDwSRmXNM1gvo5y3WTYAhmdMn/rbg==",
       "dev": true,
       "requires": {
-        "lerp": "1.0.3"
+        "lerp": "^1.0.3"
       }
     },
     "colors": {
@@ -253,11 +253,11 @@
       "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3",
-        "robust-product": "1.0.0",
-        "robust-sum": "1.0.0",
-        "signum": "0.0.0",
-        "two-sum": "1.0.0"
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
       },
       "dependencies": {
         "signum": {
@@ -278,9 +278,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "convex-hull": {
@@ -289,9 +289,9 @@
       "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
       "dev": true,
       "requires": {
-        "affine-hull": "1.0.0",
-        "incremental-convex-hull": "1.0.1",
-        "monotone-convex-hull-2d": "1.0.1"
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
       }
     },
     "core-util-is": {
@@ -311,10 +311,10 @@
       "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
       "dev": true,
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "cwise-parser": "1.0.3",
-        "static-module": "1.5.0",
-        "uglify-js": "2.8.29"
+        "cwise-compiler": "^1.1.1",
+        "cwise-parser": "^1.0.0",
+        "static-module": "^1.0.0",
+        "uglify-js": "^2.6.0"
       }
     },
     "cwise-compiler": {
@@ -323,7 +323,7 @@
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
       "dev": true,
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "cwise-parser": {
@@ -332,8 +332,8 @@
       "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
       "dev": true,
       "requires": {
-        "esprima": "1.2.5",
-        "uniq": "1.0.1"
+        "esprima": "^1.0.3",
+        "uniq": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -365,8 +365,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -392,7 +392,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "isarray": {
@@ -407,10 +407,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -426,10 +426,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "edges-to-adjacency-list": {
@@ -438,7 +438,7 @@
       "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
       "dev": true,
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "element-size": {
@@ -452,7 +452,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "es-abstract": {
@@ -460,11 +460,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -472,9 +472,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escodegen": {
@@ -482,11 +482,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       }
     },
     "esprima": {
@@ -520,10 +520,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "5.4.1",
-        "foreach": "2.0.5",
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -544,8 +544,8 @@
       "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "cubic-hermite": "1.0.0"
+        "binary-search-bounds": "^1.0.0",
+        "cubic-hermite": "^1.0.0"
       }
     },
     "findup": {
@@ -553,8 +553,8 @@
       "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
       "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
       "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0"
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
       }
     },
     "for-each": {
@@ -562,7 +562,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "requires": {
-        "is-function": "1.0.1"
+        "is-function": "~1.0.0"
       }
     },
     "foreach": {
@@ -575,8 +575,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -607,19 +607,19 @@
       "integrity": "sha512-PXyLDQR3+shlvmJg8At0bdsA1FdsotA1fRAz1zktsPhx8dwghE2aGKZ2bLLppYRndbXAgMmBhz+dz+wlZltLsw==",
       "dev": true,
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0",
-        "extract-frustum-planes": "1.0.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.1.4",
-        "gl-shader": "4.2.1",
-        "gl-state": "1.0.0",
-        "gl-vao": "1.3.0",
-        "gl-vec4": "1.0.1",
-        "glslify": "6.1.0",
-        "robust-orientation": "1.1.3",
-        "split-polygon": "1.0.0",
-        "vectorize-text": "3.0.2"
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0",
+        "extract-frustum-planes": "^1.0.0",
+        "gl-buffer": "^2.0.3",
+        "gl-mat4": "^1.0.1",
+        "gl-shader": "^4.0.4",
+        "gl-state": "^1.0.0",
+        "gl-vao": "^1.1.1",
+        "gl-vec4": "^1.0.1",
+        "glslify": "^6.1.0",
+        "robust-orientation": "^1.1.3",
+        "split-polygon": "^1.0.0",
+        "vectorize-text": "^3.0.0"
       }
     },
     "gl-buffer": {
@@ -628,9 +628,9 @@
       "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
       "dev": true,
       "requires": {
-        "ndarray": "1.0.18",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.1.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.1.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "gl-constants": {
@@ -644,7 +644,7 @@
       "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
       "dev": true,
       "requires": {
-        "gl-texture2d": "2.1.0"
+        "gl-texture2d": "^2.0.0"
       }
     },
     "gl-format-compiler-error": {
@@ -652,10 +652,10 @@
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
       "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
       "requires": {
-        "add-line-numbers": "1.0.1",
-        "gl-constants": "1.0.0",
-        "glsl-shader-name": "1.0.0",
-        "sprintf-js": "1.1.1"
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
       }
     },
     "gl-mat3": {
@@ -676,20 +676,20 @@
       "integrity": "sha512-sxqKOQA8T2V1CaNefC7X2FTbTPRXWlmzyPd+UOmeUoUYypanFufnDoNLjMEmD5Njq8M5DBg4G7POzf4Jd8272w==",
       "dev": true,
       "requires": {
-        "barycentric": "1.0.1",
-        "colormap": "2.3.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.1.4",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "6.1.0",
-        "ndarray": "1.0.18",
-        "normals": "1.1.0",
-        "polytope-closest-point": "1.0.0",
-        "simplicial-complex-contour": "1.0.2",
-        "typedarray-pool": "1.1.0"
+        "barycentric": "^1.0.1",
+        "colormap": "^2.1.0",
+        "gl-buffer": "^2.0.8",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.0.8",
+        "gl-vao": "^1.1.3",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^6.1.0",
+        "ndarray": "^1.0.15",
+        "normals": "^1.0.1",
+        "polytope-closest-point": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-quat": {
@@ -698,9 +698,9 @@
       "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
       "dev": true,
       "requires": {
-        "gl-mat3": "1.0.0",
-        "gl-vec3": "1.0.3",
-        "gl-vec4": "1.0.1"
+        "gl-mat3": "^1.0.0",
+        "gl-vec3": "^1.0.3",
+        "gl-vec4": "^1.0.0"
       }
     },
     "gl-select-static": {
@@ -709,11 +709,11 @@
       "integrity": "sha1-8+GQHfAxgdUy55WFMjBnnUr1fuk=",
       "dev": true,
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "cwise": "1.0.10",
-        "gl-fbo": "2.0.5",
-        "ndarray": "1.0.18",
-        "typedarray-pool": "1.1.0"
+        "bit-twiddle": "^1.0.2",
+        "cwise": "^1.0.3",
+        "gl-fbo": "^2.0.3",
+        "ndarray": "^1.0.15",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-shader": {
@@ -721,8 +721,8 @@
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
       "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
       "requires": {
-        "gl-format-compiler-error": "1.0.3",
-        "weakmap-shim": "1.1.1"
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
       }
     },
     "gl-spikes3d": {
@@ -731,10 +731,10 @@
       "integrity": "sha512-mXRG+3iCs4bDH7if2aOr1G5UpbNqKxfWpy7GR/afOHDSNsrq2ZjnWAwPmIJG7KdClPNPgiK30cVo7XisLt8PCQ==",
       "dev": true,
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glslify": "6.1.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.4",
+        "gl-vao": "^1.2.1",
+        "glslify": "^6.1.0"
       }
     },
     "gl-state": {
@@ -743,7 +743,7 @@
       "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
       "dev": true,
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "gl-texture2d": {
@@ -752,9 +752,9 @@
       "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
       "dev": true,
       "requires": {
-        "ndarray": "1.0.18",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.1.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-vao": {
@@ -779,12 +779,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glsl-inject-defines": {
@@ -792,9 +792,9 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
       "requires": {
-        "glsl-token-inject-block": "1.1.0",
-        "glsl-token-string": "1.0.1",
-        "glsl-tokenizer": "2.1.2"
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-inverse": {
@@ -807,8 +807,8 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
       "requires": {
-        "resolve": "0.6.3",
-        "xtend": "2.2.0"
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
       },
       "dependencies": {
         "resolve": {
@@ -828,8 +828,8 @@
       "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
       "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
       "requires": {
-        "atob-lite": "1.0.0",
-        "glsl-tokenizer": "2.1.2"
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-specular-beckmann": {
@@ -844,7 +844,7 @@
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
       "dev": true,
       "requires": {
-        "glsl-specular-beckmann": "1.1.2"
+        "glsl-specular-beckmann": "^1.1.1"
       }
     },
     "glsl-token-assignments": {
@@ -857,7 +857,7 @@
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
       "requires": {
-        "glsl-tokenizer": "2.1.2"
+        "glsl-tokenizer": "^2.0.0"
       }
     },
     "glsl-token-depth": {
@@ -870,10 +870,10 @@
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
       "requires": {
-        "glsl-token-assignments": "2.0.2",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-properties": "1.0.1",
-        "glsl-token-scope": "1.1.2"
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
       }
     },
     "glsl-token-inject-block": {
@@ -906,7 +906,7 @@
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.2.tgz",
       "integrity": "sha1-cgMHUi4DxXrzXABVGVDEpw7y37k=",
       "requires": {
-        "through2": "0.6.5"
+        "through2": "^0.6.3"
       },
       "dependencies": {
         "isarray": {
@@ -919,10 +919,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -935,8 +935,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
           }
         }
       }
@@ -946,22 +946,22 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-6.1.0.tgz",
       "integrity": "sha1-zf/P0qZXFyISjT0TNWwTbebOl0I=",
       "requires": {
-        "bl": "1.2.1",
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.3",
-        "falafel": "2.1.0",
-        "from2": "2.3.0",
+        "bl": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.0.0",
+        "from2": "^2.3.0",
         "glsl-resolve": "0.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glslify-bundle": "5.0.0",
-        "glslify-deps": "1.3.0",
-        "minimist": "1.2.0",
-        "resolve": "1.5.0",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.0",
+        "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "1.1.1",
-        "tape": "4.8.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "static-eval": "^1.1.1",
+        "tape": "^4.6.0",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
       }
     },
     "glslify-bundle": {
@@ -969,15 +969,15 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.0.0.tgz",
       "integrity": "sha1-AlKtoe+d8wtmAAbguyH9EwtIbkI=",
       "requires": {
-        "glsl-inject-defines": "1.0.3",
-        "glsl-token-defines": "1.0.0",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-descope": "1.0.2",
-        "glsl-token-scope": "1.1.2",
-        "glsl-token-string": "1.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glsl-tokenizer": "2.1.2",
-        "murmurhash-js": "1.0.0",
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
         "shallow-copy": "0.0.1"
       }
     },
@@ -986,14 +986,14 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.0.tgz",
       "integrity": "sha1-CyI0yOqePT/X9rPLfwOuWea1Glk=",
       "requires": {
-        "events": "1.1.1",
-        "findup": "0.1.5",
+        "events": "^1.0.2",
+        "findup": "^0.1.5",
         "glsl-resolve": "0.0.1",
-        "glsl-tokenizer": "2.1.2",
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
         "map-limit": "0.0.1",
-        "resolve": "1.5.0"
+        "resolve": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1006,7 +1006,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-passive-events": {
@@ -1015,7 +1015,7 @@
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "dev": true,
       "requires": {
-        "is-browser": "2.0.1"
+        "is-browser": "^2.0.1"
       }
     },
     "incremental-convex-hull": {
@@ -1024,8 +1024,8 @@
       "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "1.0.0"
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
       },
       "dependencies": {
         "simplicial-complex": {
@@ -1034,8 +1034,8 @@
           "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
           "dev": true,
           "requires": {
-            "bit-twiddle": "1.0.2",
-            "union-find": "1.0.2"
+            "bit-twiddle": "^1.0.0",
+            "union-find": "^1.0.0"
           }
         }
       }
@@ -1045,8 +1045,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1060,7 +1060,7 @@
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "1.0.0"
+        "binary-search-bounds": "^1.0.0"
       }
     },
     "invert-permutation": {
@@ -1107,7 +1107,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -1126,7 +1126,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1146,8 +1146,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "longest": {
@@ -1161,7 +1161,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       },
       "dependencies": {
         "once": {
@@ -1169,7 +1169,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -1180,7 +1180,7 @@
       "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
       "dev": true,
       "requires": {
-        "convex-hull": "1.0.3"
+        "convex-hull": "^1.0.3"
       }
     },
     "mat4-decompose": {
@@ -1189,8 +1189,8 @@
       "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
       "dev": true,
       "requires": {
-        "gl-mat4": "1.1.4",
-        "gl-vec3": "1.0.3"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2"
       }
     },
     "mat4-interpolate": {
@@ -1199,11 +1199,11 @@
       "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
       "dev": true,
       "requires": {
-        "gl-mat4": "1.1.4",
-        "gl-vec3": "1.0.3",
-        "mat4-decompose": "1.0.4",
-        "mat4-recompose": "1.0.4",
-        "quat-slerp": "1.0.1"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2",
+        "mat4-decompose": "^1.0.3",
+        "mat4-recompose": "^1.0.3",
+        "quat-slerp": "^1.0.0"
       }
     },
     "mat4-recompose": {
@@ -1212,7 +1212,7 @@
       "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
       "dev": true,
       "requires": {
-        "gl-mat4": "1.1.4"
+        "gl-mat4": "^1.0.1"
       }
     },
     "matrix-camera-controller": {
@@ -1221,10 +1221,10 @@
       "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "gl-mat4": "1.1.4",
-        "gl-vec3": "1.0.3",
-        "mat4-interpolate": "1.0.4"
+        "binary-search-bounds": "^1.0.0",
+        "gl-mat4": "^1.1.2",
+        "gl-vec3": "^1.0.3",
+        "mat4-interpolate": "^1.0.3"
       }
     },
     "minimatch": {
@@ -1232,7 +1232,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1246,7 +1246,7 @@
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "mouse-change": {
@@ -1255,7 +1255,7 @@
       "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
       "dev": true,
       "requires": {
-        "mouse-event": "1.0.5"
+        "mouse-event": "^1.0.0"
       }
     },
     "mouse-event": {
@@ -1276,9 +1276,9 @@
       "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
       "dev": true,
       "requires": {
-        "right-now": "1.0.0",
-        "signum": "1.0.0",
-        "to-px": "1.0.1"
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
       }
     },
     "murmurhash-js": {
@@ -1292,8 +1292,8 @@
       "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
       "dev": true,
       "requires": {
-        "iota-array": "1.0.0",
-        "is-buffer": "1.1.6"
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
       }
     },
     "ndarray-extract-contour": {
@@ -1302,7 +1302,7 @@
       "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
       "dev": true,
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "ndarray-ops": {
@@ -1311,7 +1311,7 @@
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
       "dev": true,
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     },
     "ndarray-sort": {
@@ -1320,7 +1320,7 @@
       "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
       "dev": true,
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "nextafter": {
@@ -1329,7 +1329,7 @@
       "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
       "dev": true,
       "requires": {
-        "double-bits": "1.1.1"
+        "double-bits": "^1.1.0"
       }
     },
     "normals": {
@@ -1359,7 +1359,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -1367,12 +1367,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "orbit-camera-controller": {
@@ -1381,8 +1381,8 @@
       "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
       "dev": true,
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.1.4"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.3"
       }
     },
     "pad-left": {
@@ -1390,7 +1390,7 @@
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
       "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.3.0"
       }
     },
     "parse-unit": {
@@ -1415,7 +1415,7 @@
       "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
       "dev": true,
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "permutation-rank": {
@@ -1424,8 +1424,8 @@
       "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
       "dev": true,
       "requires": {
-        "invert-permutation": "1.0.0",
-        "typedarray-pool": "1.1.0"
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "planar-dual": {
@@ -1434,8 +1434,8 @@
       "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
       "dev": true,
       "requires": {
-        "compare-angle": "1.0.1",
-        "dup": "1.0.0"
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "planar-graph-to-polyline": {
@@ -1444,13 +1444,13 @@
       "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
       "dev": true,
       "requires": {
-        "edges-to-adjacency-list": "1.0.0",
-        "planar-dual": "1.0.2",
-        "point-in-big-polygon": "2.0.0",
-        "robust-orientation": "1.1.3",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2",
-        "uniq": "1.0.1"
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.0",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
       }
     },
     "point-in-big-polygon": {
@@ -1459,10 +1459,10 @@
       "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "interval-tree-1d": "1.0.3",
-        "robust-orientation": "1.1.3",
-        "slab-decomposition": "1.0.2"
+        "binary-search-bounds": "^1.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
       }
     },
     "polytope-closest-point": {
@@ -1471,7 +1471,7 @@
       "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
       "dev": true,
       "requires": {
-        "numeric": "1.2.6"
+        "numeric": "^1.2.6"
       }
     },
     "prelude-ls": {
@@ -1490,7 +1490,7 @@
       "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
       "dev": true,
       "requires": {
-        "gl-quat": "1.0.0"
+        "gl-quat": "^1.0.0"
       }
     },
     "quote-stream": {
@@ -1500,7 +1500,7 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8",
-        "through2": "0.4.2"
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "isarray": {
@@ -1527,10 +1527,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1545,8 +1545,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -1555,7 +1555,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -1566,7 +1566,7 @@
       "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
       "dev": true,
       "requires": {
-        "big-rat": "1.0.4"
+        "big-rat": "^1.0.3"
       }
     },
     "readable-stream": {
@@ -1574,13 +1574,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "repeat-string": {
@@ -1593,7 +1593,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resumer": {
@@ -1601,7 +1601,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "right-align": {
@@ -1610,7 +1610,7 @@
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "right-now": {
@@ -1631,10 +1631,10 @@
       "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
       "dev": true,
       "requires": {
-        "robust-compress": "1.0.0",
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-compress": "^1.0.0",
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-dot-product": {
@@ -1643,8 +1643,8 @@
       "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
       "dev": true,
       "requires": {
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-in-sphere": {
@@ -1653,10 +1653,10 @@
       "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
       "dev": true,
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-linear-solve": {
@@ -1665,7 +1665,7 @@
       "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
       "dev": true,
       "requires": {
-        "robust-determinant": "1.1.0"
+        "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {
@@ -1674,10 +1674,10 @@
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
       "dev": true,
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
       }
     },
     "robust-product": {
@@ -1686,8 +1686,8 @@
       "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
       "dev": true,
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0"
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "robust-scale": {
@@ -1696,8 +1696,8 @@
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
       "dev": true,
       "requires": {
-        "two-product": "1.0.2",
-        "two-sum": "1.0.0"
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
       }
     },
     "robust-segment-intersect": {
@@ -1706,7 +1706,7 @@
       "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "robust-subtract": {
@@ -1743,8 +1743,8 @@
       "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
       "dev": true,
       "requires": {
-        "bit-twiddle": "0.0.2",
-        "union-find": "0.0.4"
+        "bit-twiddle": "~0.0.1",
+        "union-find": "~0.0.3"
       },
       "dependencies": {
         "bit-twiddle": {
@@ -1767,10 +1767,10 @@
       "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
       "dev": true,
       "requires": {
-        "marching-simplex-table": "1.0.0",
-        "ndarray": "1.0.18",
-        "ndarray-sort": "1.0.1",
-        "typedarray-pool": "1.1.0"
+        "marching-simplex-table": "^1.0.0",
+        "ndarray": "^1.0.15",
+        "ndarray-sort": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "simplify-planar-graph": {
@@ -1779,8 +1779,8 @@
       "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
       "dev": true,
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "0.3.3"
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
       }
     },
     "slab-decomposition": {
@@ -1789,9 +1789,9 @@
       "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
       "dev": true,
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^1.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
       }
     },
     "source-map": {
@@ -1805,8 +1805,8 @@
       "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
       "dev": true,
       "requires": {
-        "robust-dot-product": "1.0.0",
-        "robust-sum": "1.0.0"
+        "robust-dot-product": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "sprintf-js": {
@@ -1824,7 +1824,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-1.1.1.tgz",
       "integrity": "sha1-yoEwIQNUzxPZpyK8fpI3eEV7sZI=",
       "requires": {
-        "escodegen": "1.9.0"
+        "escodegen": "^1.8.1"
       }
     },
     "static-module": {
@@ -1833,17 +1833,17 @@
       "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.1",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
+        "concat-stream": "~1.6.0",
+        "duplexer2": "~0.0.2",
+        "escodegen": "~1.3.2",
+        "falafel": "^2.1.0",
+        "has": "^1.0.0",
+        "object-inspect": "~0.4.0",
+        "quote-stream": "~0.0.0",
+        "readable-stream": "~1.0.27-1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "~0.2.0",
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "escodegen": {
@@ -1852,10 +1852,10 @@
           "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
           "dev": true,
           "requires": {
-            "esprima": "1.1.1",
-            "estraverse": "1.5.1",
-            "esutils": "1.0.0",
-            "source-map": "0.1.43"
+            "esprima": "~1.1.1",
+            "estraverse": "~1.5.0",
+            "esutils": "~1.0.0",
+            "source-map": "~0.1.33"
           }
         },
         "esprima": {
@@ -1900,10 +1900,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "source-map": {
@@ -1913,7 +1913,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "static-eval": {
@@ -1922,7 +1922,7 @@
           "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
           "dev": true,
           "requires": {
-            "escodegen": "0.0.28"
+            "escodegen": "~0.0.24"
           },
           "dependencies": {
             "escodegen": {
@@ -1931,9 +1931,9 @@
               "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
               "dev": true,
               "requires": {
-                "esprima": "1.0.4",
-                "estraverse": "1.3.2",
-                "source-map": "0.1.43"
+                "esprima": "~1.0.2",
+                "estraverse": "~1.3.0",
+                "source-map": ">= 0.1.2"
               }
             },
             "esprima": {
@@ -1962,8 +1962,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -1972,7 +1972,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -1987,9 +1987,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -1997,7 +1997,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "surface-nets": {
@@ -2006,9 +2006,9 @@
       "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
       "dev": true,
       "requires": {
-        "ndarray-extract-contour": "1.0.1",
-        "triangulate-hypercube": "1.0.1",
-        "zero-crossings": "1.0.1"
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
       }
     },
     "tape": {
@@ -2016,19 +2016,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
       "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.2",
+        "function-bind": "~1.1.0",
+        "glob": "~7.1.2",
+        "has": "~1.0.1",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.3.0",
+        "resolve": "~1.4.0",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "resolve": {
@@ -2036,7 +2036,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
           "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -2051,8 +2051,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.4",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "to-px": {
@@ -2061,7 +2061,7 @@
       "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
       "dev": true,
       "requires": {
-        "parse-unit": "1.0.1"
+        "parse-unit": "^1.0.1"
       }
     },
     "triangulate-hypercube": {
@@ -2070,9 +2070,9 @@
       "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
       "dev": true,
       "requires": {
-        "gamma": "0.1.0",
-        "permutation-parity": "1.0.0",
-        "permutation-rank": "1.0.0"
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
       }
     },
     "triangulate-polyline": {
@@ -2081,7 +2081,7 @@
       "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
       "dev": true,
       "requires": {
-        "cdt2d": "1.0.0"
+        "cdt2d": "^1.0.0"
       }
     },
     "turntable-camera-controller": {
@@ -2090,9 +2090,9 @@
       "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
       "dev": true,
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.1.4",
-        "gl-vec3": "1.0.3"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.2",
+        "gl-vec3": "^1.0.2"
       }
     },
     "two-product": {
@@ -2112,7 +2112,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -2126,8 +2126,8 @@
       "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
       "dev": true,
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0"
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "uglify-js": {
@@ -2136,9 +2136,9 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -2171,13 +2171,13 @@
       "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
       "dev": true,
       "requires": {
-        "cdt2d": "1.0.0",
-        "clean-pslg": "1.1.2",
-        "ndarray": "1.0.18",
-        "planar-graph-to-polyline": "1.0.5",
-        "simplify-planar-graph": "2.0.1",
-        "surface-nets": "1.0.2",
-        "triangulate-polyline": "1.0.3"
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.0",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
       }
     },
     "weakmap-shim": {
@@ -2212,9 +2212,9 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -2224,7 +2224,7 @@
       "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
       "dev": true,
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -802,6 +802,11 @@
       "resolved": "https://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
       "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
     },
+    "glsl-out-of-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.1.tgz",
+      "integrity": "sha512-vSRItjpicAkzo0bMmMgCXWgbmVplLnkqWVYrJUQEDu0H1iosylygMP+RQ2ZtK43xFIxaYeDJ1yGgZ0vnOBG3AQ=="
+    },
     "glsl-resolve": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -803,9 +803,9 @@
       "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
     },
     "glsl-out-of-range": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.1.tgz",
-      "integrity": "sha512-vSRItjpicAkzo0bMmMgCXWgbmVplLnkqWVYrJUQEDu0H1iosylygMP+RQ2ZtK43xFIxaYeDJ1yGgZ0vnOBG3AQ=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.2.tgz",
+      "integrity": "sha512-Qej48sfhSajxvfOmFNz5RV37DEHUjVTz38id1Y/Nt0kAXEe8IQSOXhKvlnD+uDpU5JKS6fLxlxLy8lJ/bepqAQ=="
     },
     "glsl-resolve": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gl-shader": "^4.2.1",
     "gl-vec3": "^1.0.0",
     "glsl-inverse": "^1.0.0",
+    "glsl-out-of-range": "^1.0.1",
     "glslify": "^6.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gl-shader": "^4.2.1",
     "gl-vec3": "^1.0.0",
     "glsl-inverse": "^1.0.0",
-    "glsl-out-of-range": "^1.0.1",
+    "glsl-out-of-range": "^1.0.2",
     "glslify": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR is another module required to be updated to enable drawing the scenes with reversed bounds. In plotly.is such ranges could be set using autorange:'reversed' or range:[greater value, smaller value] .
Please refer to plotly [issue](https://github.com/plotly/plotly.js/issues/1940) and this [PR](https://github.com/plotly/plotly.js/pull/3071).

Note: In the case of gl-cone3d, the range conditions are now applied in the triangle-fragment shader as well. To allow this functionality the triangle-vertex shader is also modified to provide the position parameter.

@alexcjohnson