### PR TITLE
Make gl-cone3d mesh code reusable for gl-streamtube3d

### DIFF
--- a/cone.js
+++ b/cone.js
@@ -118,4 +118,11 @@ module.exports = function(vectorfield, bounds) {
 	return geo;
 };
 
-module.exports.createConeMesh = require('./lib/conemesh');
+var shaders = require('./lib/shaders');
+module.exports.createMesh = require('./lib/conemesh');
+module.exports.createConeMesh = function(gl, params) {
+	return module.exports.createMesh(gl, params, {
+		shaders: shaders,
+		traceType: 'cone'
+	});
+}

--- a/cone.js
+++ b/cone.js
@@ -9,7 +9,6 @@ module.exports = function(vectorfield, bounds) {
 		positions: [],
 		vertexIntensity: [],
 		vertexIntensityBounds: vectorfield.vertexIntensityBounds,
-		vertexNormals: [],
 		vectors: [],
 		cells: [],
 		coneOffset: vectorfield.coneOffset,
@@ -79,9 +78,6 @@ module.exports = function(vectorfield, bounds) {
 	}
 	geo.vectorScale = vectorScale;
 
-	var nml = vec3.create();
-	vec3.set(nml, 0, 1, 0); // not clear why using this direction?!
-
 	var coneScale = vectorfield.coneSize || 0.5;
 
 	if (vectorfield.absoluteConeSize) {
@@ -113,9 +109,6 @@ module.exports = function(vectorfield, bounds) {
 
 			geo.vertexIntensity.push(intensity, intensity, intensity);
 			geo.vertexIntensity.push(intensity, intensity, intensity);
-
-			geo.vertexNormals.push(nml, nml, nml);
-			geo.vertexNormals.push(nml, nml, nml);
 
 			var m = geo.positions.length;
 			geo.cells.push([m-6, m-5, m-4], [m-3, m-2, m-1]);

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -110,21 +110,6 @@ function genColormap(param) {
   return ndarray(result, [256,256,4], [4,0,1])
 }
 
-function unpackIntensity(cells, numVerts, cellIntensity) {
-  var result = new Array(numVerts)
-  for(var i=0; i<numVerts; ++i) {
-    result[i] = 0
-  }
-  var numCells = cells.length
-  for(var i=0; i<numCells; ++i) {
-    var c = cells[i]
-    for(var j=0; j<c.length; ++j) {
-      result[c[j]] = cellIntensity[i]
-    }
-  }
-  return result
-}
-
 function takeZComponent(array) {
   var n = array.length
   var result = new Array(n)
@@ -178,10 +163,7 @@ proto.update = function(params) {
     this.coneOffset = params.coneOffset
   }
 
-  if(params.texture) {
-    this.texture.dispose()
-    this.texture = createTexture(gl, params.texture)
-  } else if (params.colormap) {
+  if (params.colormap) {
     this.texture.shape = [256,256]
     this.texture.minFilter = gl.LINEAR_MIPMAP_LINEAR
     this.texture.magFilter = gl.LINEAR
@@ -209,49 +191,35 @@ proto.update = function(params) {
   this.vectors   = vectors
 
   //Compute colors
-  var vertexColors    = params.vertexColors
-  var cellColors      = params.cellColors
   var meshColor       = params.meshColor || [1,1,1,1]
 
   //UVs
-  var vertexUVs       = params.vertexUVs
   var vertexIntensity = params.vertexIntensity
-  var cellUVs         = params.cellUVs
-  var cellIntensity   = params.cellIntensity
 
   var intensityLo     = Infinity
   var intensityHi     = -Infinity
-  if(!vertexUVs && !cellUVs) {
-    if(vertexIntensity) {
-      if(params.vertexIntensityBounds) {
-        intensityLo = +params.vertexIntensityBounds[0]
-        intensityHi = +params.vertexIntensityBounds[1]
-      } else {
-        for(var i=0; i<vertexIntensity.length; ++i) {
-          var f = vertexIntensity[i]
-          intensityLo = Math.min(intensityLo, f)
-          intensityHi = Math.max(intensityHi, f)
-        }
-      }
-    } else if(cellIntensity) {
-      for(var i=0; i<cellIntensity.length; ++i) {
-        var f = cellIntensity[i]
-        intensityLo = Math.min(intensityLo, f)
-        intensityHi = Math.max(intensityHi, f)
-      }
+
+  if(vertexIntensity) {
+    if(params.vertexIntensityBounds) {
+      intensityLo = +params.vertexIntensityBounds[0]
+      intensityHi = +params.vertexIntensityBounds[1]
     } else {
-      for(var i=0; i<positions.length; ++i) {
-        var f = positions[i][2]
+      for(var i=0; i<vertexIntensity.length; ++i) {
+        var f = vertexIntensity[i]
         intensityLo = Math.min(intensityLo, f)
         intensityHi = Math.max(intensityHi, f)
       }
+    }
+  } else {
+    for(var i=0; i<positions.length; ++i) {
+      var f = positions[i][2]
+      intensityLo = Math.min(intensityLo, f)
+      intensityHi = Math.max(intensityHi, f)
     }
   }
 
   if(vertexIntensity) {
     this.intensity = vertexIntensity
-  } else if(cellIntensity) {
-    this.intensity = unpackIntensity(cells, positions.length, cellIntensity)
   } else {
     this.intensity = takeZComponent(positions)
   }
@@ -297,14 +265,7 @@ fill_loop:
           var w = vectors[v]
           tVec.push(w[0], w[1], w[2], w[3] || 0)
 
-          var c
-          if(vertexColors) {
-            c = vertexColors[v]
-          } else if(cellColors) {
-            c = cellColors[i]
-          } else {
-            c = meshColor
-          }
+          var c = meshColor
           if(c.length === 3) {
             tCol.push(c[0], c[1], c[2], 1)
           } else {
@@ -312,17 +273,9 @@ fill_loop:
           }
 
           var uv
-          if(vertexUVs) {
-            uv = vertexUVs[v]
-          } else if(vertexIntensity) {
+          if(vertexIntensity) {
             uv = [
               (vertexIntensity[v] - intensityLo) /
-              (intensityHi - intensityLo), 0]
-          } else if(cellUVs) {
-            uv = cellUVs[i]
-          } else if(cellIntensity) {
-            uv = [
-              (cellIntensity[i] - intensityLo) /
               (intensityHi - intensityLo), 0]
           } else {
             uv = [

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -64,7 +64,7 @@ function SimplicialMesh(gl
   this.opacity       = 1
 
   this.traceType     = traceType
-  this.tubeScale     = 1 // used in tube
+  this.tubeScale     = 1 // used in streamtube
   this.coneScale     = 2 // used in cone
   this.vectorScale   = 1 // used in cone
   this.coneOffset    = 0.25 // used in cone
@@ -147,7 +147,7 @@ proto.update = function(params) {
     this.fresnel = params.fresnel
   }
 
-  // use in tube
+  // use in streamtube
   if (params.tubeScale !== undefined) {
     this.tubeScale = params.tubeScale
   }
@@ -450,7 +450,7 @@ proto.pick = function(pickData) {
 
   if(this.traceType === 'cone') {
     result.index = Math.floor(cell[1] / 48)
-  } else if(this.traceType === 'tube') {
+  } else if(this.traceType === 'streamtube') {
     result.intensity = this.intensity[cell[1]]
     result.velocity = this.vectors[cell[1]].slice(0, 3)
     result.divergence = this.vectors[cell[1]][3]

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -1,13 +1,9 @@
 'use strict'
 
-var DEFAULT_VERTEX_NORMALS_EPSILON = 1e-6; // may be too large if triangles are very small
-var DEFAULT_FACE_NORMALS_EPSILON = 1e-6;
-
 var createShader  = require('gl-shader')
 var createBuffer  = require('gl-buffer')
 var createVAO     = require('gl-vao')
 var createTexture = require('gl-texture2d')
-var normals       = require('normals')
 var multiply      = require('gl-mat4/multiply')
 var invert        = require('gl-mat4/invert')
 var ndarray       = require('ndarray')
@@ -34,7 +30,6 @@ function SimplicialMesh(gl
   , triangleIds
   , triangleColors
   , triangleUVs
-  , triangleNormals
   , triangleVAO
   , edgePositions
   , edgeIds
@@ -64,7 +59,6 @@ function SimplicialMesh(gl
   this.trianglePositions = trianglePositions
   this.triangleVectors   = triangleVectors
   this.triangleColors    = triangleColors
-  this.triangleNormals   = triangleNormals
   this.triangleUVs       = triangleUVs
   this.triangleIds       = triangleIds
   this.triangleVAO       = triangleVAO
@@ -301,18 +295,6 @@ proto.update = function(params) {
   //Save geometry data for picking calculations
   this.cells     = cells
   this.positions = positions
-
-  //Compute normals
-  var vertexNormals = params.vertexNormals
-  var cellNormals   = params.cellNormals
-  var vertexNormalsEpsilon = params.vertexNormalsEpsilon === void(0) ? DEFAULT_VERTEX_NORMALS_EPSILON : params.vertexNormalsEpsilon
-  var faceNormalsEpsilon = params.faceNormalsEpsilon === void(0) ? DEFAULT_FACE_NORMALS_EPSILON : params.faceNormalsEpsilon
-  if(params.useFacetNormals && !cellNormals) {
-    cellNormals = normals.faceNormals(cells, positions, faceNormalsEpsilon)
-  }
-  if(!cellNormals && !vertexNormals) {
-    vertexNormals = normals.vertexNormals(cells, positions, vertexNormalsEpsilon)
-  }
 
   //Compute colors
   var vertexColors    = params.vertexColors
@@ -560,14 +542,6 @@ fill_loop:
           }
           tUVs.push(uv[0], uv[1])
 
-          var q
-          if(vertexNormals) {
-            q = vertexNormals[v]
-          } else {
-            q = cellNormals[i]
-          }
-          tNor.push(q[0], q[1], q[2])
-
           tIds.push(i)
         }
         triangleCount += 1
@@ -597,7 +571,6 @@ fill_loop:
   this.triangleVectors.update(tVec)
   this.triangleColors.update(tCol)
   this.triangleUVs.update(tUVs)
-  this.triangleNormals.update(tNor)
   this.triangleIds.update(new Uint32Array(tIds))
 }
 
@@ -765,7 +738,6 @@ proto.dispose = function() {
   this.triangleVectors.dispose()
   this.triangleColors.dispose()
   this.triangleUVs.dispose()
-  this.triangleNormals.dispose()
   this.triangleIds.dispose()
 
   this.edgeVAO.dispose()
@@ -792,7 +764,7 @@ function createMeshShader(gl) {
   shader.attributes.position.location = 0
   shader.attributes.color.location    = 2
   shader.attributes.uv.location       = 3
-  shader.attributes.vector.location   = 5
+  shader.attributes.vector.location   = 4
   return shader
 }
 
@@ -801,7 +773,7 @@ function createPickShader(gl) {
   var shader = createShader(gl, pickShader.vertex, pickShader.fragment, null, pickShader.attributes)
   shader.attributes.position.location = 0
   shader.attributes.id.location       = 1
-  shader.attributes.vector.location   = 5
+  shader.attributes.vector.location   = 4
   return shader
 }
 
@@ -826,7 +798,6 @@ function createSimplicialMesh(gl, params) {
   var triangleVectors   = createBuffer(gl)
   var triangleColors    = createBuffer(gl)
   var triangleUVs       = createBuffer(gl)
-  var triangleNormals   = createBuffer(gl)
   var triangleIds       = createBuffer(gl)
   var triangleVAO       = createVAO(gl, [
     { buffer: trianglePositions,
@@ -845,10 +816,6 @@ function createSimplicialMesh(gl, params) {
     { buffer: triangleUVs,
       type: gl.FLOAT,
       size: 2
-    },
-    { buffer: triangleNormals,
-      type: gl.FLOAT,
-      size: 3
     },
     { buffer: triangleVectors,
       type: gl.FLOAT,
@@ -925,7 +892,6 @@ function createSimplicialMesh(gl, params) {
     , triangleIds
     , triangleColors
     , triangleUVs
-    , triangleNormals
     , triangleVAO
     , edgePositions
     , edgeIds

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -25,17 +25,6 @@ function SimplicialMesh(gl
   , triangleColors
   , triangleUVs
   , triangleVAO
-  , edgePositions
-  , edgeIds
-  , edgeColors
-  , edgeUVs
-  , edgeVAO
-  , pointPositions
-  , pointIds
-  , pointColors
-  , pointUVs
-  , pointSizes
-  , pointVAO
   , traceType) {
 
   this.gl                = gl
@@ -56,22 +45,6 @@ function SimplicialMesh(gl
   this.triangleIds       = triangleIds
   this.triangleVAO       = triangleVAO
   this.triangleCount     = 0
-
-  this.lineWidth         = 1
-  this.edgePositions     = edgePositions
-  this.edgeColors        = edgeColors
-  this.edgeUVs           = edgeUVs
-  this.edgeIds           = edgeIds
-  this.edgeVAO           = edgeVAO
-  this.edgeCount         = 0
-
-  this.pointPositions    = pointPositions
-  this.pointColors       = pointColors
-  this.pointUVs          = pointUVs
-  this.pointSizes        = pointSizes
-  this.pointIds          = pointIds
-  this.pointVAO          = pointVAO
-  this.pointCount        = 0
 
   this.pickId            = 1
   this.bounds            = [
@@ -167,9 +140,6 @@ proto.update = function(params) {
 
   this.dirty = true
 
-  if('lineWidth' in params) {
-    this.lineWidth = params.lineWidth
-  }
   if('lightPosition' in params) {
     this.lightPosition = params.lightPosition
   }
@@ -230,20 +200,8 @@ proto.update = function(params) {
   var tPos = []
   var tVec = []
   var tCol = []
-  var tNor = []
   var tUVs = []
   var tIds = []
-
-  var ePos = []
-  var eCol = []
-  var eUVs = []
-  var eIds = []
-
-  var pPos = []
-  var pCol = []
-  var pUVs = []
-  var pSiz = []
-  var pIds = []
 
   //Save geometry data for picking calculations
   this.cells     = cells
@@ -298,10 +256,6 @@ proto.update = function(params) {
     this.intensity = takeZComponent(positions)
   }
 
-  //Point size
-  var pointSizes      = params.pointSizes
-  var meshPointSize   = params.pointSize || 1.0
-
   //Update bounds
   this.bounds       = [[Infinity,Infinity,Infinity], [-Infinity,-Infinity,-Infinity]]
   for(var i=0; i<positions.length; ++i) {
@@ -317,130 +271,11 @@ proto.update = function(params) {
 
   //Pack cells into buffers
   var triangleCount = 0
-  var edgeCount = 0
-  var pointCount = 0
 
 fill_loop:
   for(var i=0; i<cells.length; ++i) {
     var cell = cells[i]
     switch(cell.length) {
-      case 1:
-
-        var v = cell[0]
-        var p = positions[v]
-
-        //Check NaNs
-        for(var j=0; j<3; ++j) {
-          if(isNaN(p[j]) || !isFinite(p[j])) {
-            continue fill_loop
-          }
-        }
-
-        pPos.push(p[0], p[1], p[2], p[3])
-
-        var c
-        if(vertexColors) {
-          c = vertexColors[v]
-        } else if(cellColors) {
-          c = cellColors[i]
-        } else {
-          c = meshColor
-        }
-        if(c.length === 3) {
-          pCol.push(c[0], c[1], c[2], 1)
-        } else {
-          pCol.push(c[0], c[1], c[2], c[3])
-        }
-
-        var uv
-        if(vertexUVs) {
-          uv = vertexUVs[v]
-        } else if(vertexIntensity) {
-          uv = [
-            (vertexIntensity[v] - intensityLo) /
-            (intensityHi - intensityLo), 0]
-        } else if(cellUVs) {
-          uv = cellUVs[i]
-        } else if(cellIntensity) {
-          uv = [
-            (cellIntensity[i] - intensityLo) /
-            (intensityHi - intensityLo), 0]
-        } else {
-          uv = [
-            (p[2] - intensityLo) /
-            (intensityHi - intensityLo), 0]
-        }
-        pUVs.push(uv[0], uv[1])
-
-        if(pointSizes) {
-          pSiz.push(pointSizes[v])
-        } else {
-          pSiz.push(meshPointSize)
-        }
-
-        pIds.push(i)
-
-        pointCount += 1
-      break
-
-      case 2:
-
-        //Check NaNs
-        for(var j=0; j<2; ++j) {
-          var v = cell[j]
-          var p = positions[v]
-          for(var k=0; k<3; ++k) {
-            if(isNaN(p[k]) || !isFinite(p[k])) {
-              continue fill_loop
-            }
-          }
-        }
-
-        for(var j=0; j<2; ++j) {
-          var v = cell[j]
-          var p = positions[v]
-
-          ePos.push(p[0], p[1], p[2])
-
-          var c
-          if(vertexColors) {
-            c = vertexColors[v]
-          } else if(cellColors) {
-            c = cellColors[i]
-          } else {
-            c = meshColor
-          }
-          if(c.length === 3) {
-            eCol.push(c[0], c[1], c[2], 1)
-          } else {
-            eCol.push(c[0], c[1], c[2], c[3])
-          }
-
-          var uv
-          if(vertexUVs) {
-            uv = vertexUVs[v]
-          } else if(vertexIntensity) {
-            uv = [
-              (vertexIntensity[v] - intensityLo) /
-              (intensityHi - intensityLo), 0]
-          } else if(cellUVs) {
-            uv = cellUVs[i]
-          } else if(cellIntensity) {
-            uv = [
-              (cellIntensity[i] - intensityLo) /
-              (intensityHi - intensityLo), 0]
-          } else {
-            uv = [
-              (p[2] - intensityLo) /
-              (intensityHi - intensityLo), 0]
-          }
-          eUVs.push(uv[0], uv[1])
-
-          eIds.push(i)
-        }
-        edgeCount += 1
-      break
-
       case 3:
         //Check NaNs
         for(var j=0; j<3; ++j) {
@@ -506,20 +341,7 @@ fill_loop:
     }
   }
 
-  this.pointCount     = pointCount
-  this.edgeCount      = edgeCount
   this.triangleCount  = triangleCount
-
-  this.pointPositions.update(pPos)
-  this.pointColors.update(pCol)
-  this.pointUVs.update(pUVs)
-  this.pointSizes.update(pSiz)
-  this.pointIds.update(new Uint32Array(pIds))
-
-  this.edgePositions.update(ePos)
-  this.edgeColors.update(eCol)
-  this.edgeUVs.update(eUVs)
-  this.edgeIds.update(new Uint32Array(eIds))
 
   this.trianglePositions.update(tPos)
   this.triangleVectors.update(tVec)
@@ -651,14 +473,6 @@ proto.drawPick = function(params) {
     gl.drawArrays(gl.TRIANGLES, 0, this.triangleCount*3)
     this.triangleVAO.unbind()
   }
-
-  if(this.edgeCount > 0) {
-    this.edgeVAO.bind()
-    gl.lineWidth(this.lineWidth * this.pixelRatio)
-    gl.drawArrays(gl.LINES, 0, this.edgeCount*2)
-    this.edgeVAO.unbind()
-  }
-
 }
 
 
@@ -706,19 +520,6 @@ proto.dispose = function() {
   this.triangleColors.dispose()
   this.triangleUVs.dispose()
   this.triangleIds.dispose()
-
-  this.edgeVAO.dispose()
-  this.edgePositions.dispose()
-  this.edgeColors.dispose()
-  this.edgeUVs.dispose()
-  this.edgeIds.dispose()
-
-  this.pointVAO.dispose()
-  this.pointPositions.dispose()
-  this.pointColors.dispose()
-  this.pointUVs.dispose()
-  this.pointSizes.dispose()
-  this.pointIds.dispose()
 }
 
 function createMeshShader(gl, shaders) {
@@ -798,59 +599,6 @@ function createSimplicialMesh(gl, params, opts) {
     }
   ])
 
-  var edgePositions = createBuffer(gl)
-  var edgeColors    = createBuffer(gl)
-  var edgeUVs       = createBuffer(gl)
-  var edgeIds       = createBuffer(gl)
-  var edgeVAO       = createVAO(gl, [
-    { buffer: edgePositions,
-      type: gl.FLOAT,
-      size: 3
-    },
-    { buffer: edgeIds,
-      type: gl.UNSIGNED_BYTE,
-      size: 4,
-      normalized: true
-    },
-    { buffer: edgeColors,
-      type: gl.FLOAT,
-      size: 4
-    },
-    { buffer: edgeUVs,
-      type: gl.FLOAT,
-      size: 2
-    }
-  ])
-
-  var pointPositions  = createBuffer(gl)
-  var pointColors     = createBuffer(gl)
-  var pointUVs        = createBuffer(gl)
-  var pointSizes      = createBuffer(gl)
-  var pointIds        = createBuffer(gl)
-  var pointVAO        = createVAO(gl, [
-    { buffer: pointPositions,
-      type: gl.FLOAT,
-      size: 3
-    },
-    { buffer: pointIds,
-      type: gl.UNSIGNED_BYTE,
-      size: 4,
-      normalized: true
-    },
-    { buffer: pointColors,
-      type: gl.FLOAT,
-      size: 4
-    },
-    { buffer: pointUVs,
-      type: gl.FLOAT,
-      size: 2
-    },
-    { buffer: pointSizes,
-      type: gl.FLOAT,
-      size: 1
-    }
-  ])
-
   var mesh = new SimplicialMesh(gl
     , meshTexture
     , triShader
@@ -861,17 +609,6 @@ function createSimplicialMesh(gl, params, opts) {
     , triangleColors
     , triangleUVs
     , triangleVAO
-    , edgePositions
-    , edgeIds
-    , edgeColors
-    , edgeUVs
-    , edgeVAO
-    , pointPositions
-    , pointIds
-    , pointColors
-    , pointUVs
-    , pointSizes
-    , pointVAO
     , opts.traceType || 'cone'
   )
 

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -8,8 +8,6 @@ var multiply      = require('gl-mat4/multiply')
 var invert        = require('gl-mat4/invert')
 var ndarray       = require('ndarray')
 var colormap      = require('colormap')
-var getContour    = require('simplicial-complex-contour')
-var pool          = require('typedarray-pool')
 
 var IDENTITY = [
   1,0,0,0,
@@ -38,8 +36,6 @@ function SimplicialMesh(gl
   , pointUVs
   , pointSizes
   , pointVAO
-  , contourPositions
-  , contourVAO
   , traceType) {
 
   this.gl                = gl
@@ -76,13 +72,6 @@ function SimplicialMesh(gl
   this.pointIds          = pointIds
   this.pointVAO          = pointVAO
   this.pointCount        = 0
-
-  this.contourLineWidth  = 1
-  this.contourPositions  = contourPositions
-  this.contourVAO        = contourVAO
-  this.contourCount      = 0
-  this.contourColor      = [0,0,0]
-  this.contourEnable     = false
 
   this.pickId            = 1
   this.bounds            = [
@@ -172,53 +161,12 @@ function takeZComponent(array) {
   return result
 }
 
-proto.highlight = function(selection) {
-  if(!selection || !this.contourEnable) {
-    this.contourCount = 0
-    return
-  }
-  var level = getContour(this.cells, this.intensity, selection.intensity)
-  var cells         = level.cells
-  var vertexIds     = level.vertexIds
-  var vertexWeights = level.vertexWeights
-  var numCells = cells.length
-  var result = pool.mallocFloat32(2 * 3 * numCells)
-  var ptr = 0
-  for(var i=0; i<numCells; ++i) {
-    var c = cells[i]
-    for(var j=0; j<2; ++j) {
-      var v = c[0]
-      if(c.length === 2) {
-        v = c[j]
-      }
-      var a = vertexIds[v][0]
-      var b = vertexIds[v][1]
-      var w = vertexWeights[v]
-      var wi = 1.0 - w
-      var pa = this.positions[a]
-      var pb = this.positions[b]
-      for(var k=0; k<3; ++k) {
-        result[ptr++] = w * pa[k] + wi * pb[k]
-      }
-    }
-  }
-  this.contourCount = (ptr / 3)|0
-  this.contourPositions.update(result.subarray(0, ptr))
-  pool.free(result)
-}
-
 proto.update = function(params) {
   params = params || {}
   var gl = this.gl
 
   this.dirty = true
 
-  if('contourEnable' in params) {
-    this.contourEnable = params.contourEnable
-  }
-  if('contourColor' in params) {
-    this.contourColor = params.contourColor
-  }
   if('lineWidth' in params) {
     this.lineWidth = params.lineWidth
   }
@@ -618,8 +566,6 @@ proto.drawTransparent = proto.draw = function(params) {
     coneScale: this.coneScale,
     coneOffset: this.coneOffset,
 
-    contourColor: this.contourColor,
-
     texture:    0
   }
 
@@ -773,9 +719,6 @@ proto.dispose = function() {
   this.pointUVs.dispose()
   this.pointSizes.dispose()
   this.pointIds.dispose()
-
-  this.contourVAO.dispose()
-  this.contourPositions.dispose()
 }
 
 function createMeshShader(gl, shaders) {
@@ -908,13 +851,6 @@ function createSimplicialMesh(gl, params, opts) {
     }
   ])
 
-  var contourPositions = createBuffer(gl)
-  var contourVAO       = createVAO(gl, [
-    { buffer: contourPositions,
-      type:   gl.FLOAT,
-      size:   3
-    }])
-
   var mesh = new SimplicialMesh(gl
     , meshTexture
     , triShader
@@ -936,8 +872,6 @@ function createSimplicialMesh(gl, params, opts) {
     , pointUVs
     , pointSizes
     , pointVAO
-    , contourPositions
-    , contourVAO
     , opts.traceType || 'cone'
   )
 

--- a/lib/conemesh.js
+++ b/lib/conemesh.js
@@ -10,10 +10,6 @@ var ndarray       = require('ndarray')
 var colormap      = require('colormap')
 var getContour    = require('simplicial-complex-contour')
 var pool          = require('typedarray-pool')
-var shaders       = require('./shaders')
-
-var meshShader    = shaders.meshShader
-var pickShader    = shaders.pickShader
 
 var IDENTITY = [
   1,0,0,0,
@@ -43,7 +39,8 @@ function SimplicialMesh(gl
   , pointSizes
   , pointVAO
   , contourPositions
-  , contourVAO) {
+  , contourVAO
+  , traceType) {
 
   this.gl                = gl
   this.pixelRatio         = 1
@@ -85,7 +82,7 @@ function SimplicialMesh(gl
   this.contourVAO        = contourVAO
   this.contourCount      = 0
   this.contourColor      = [0,0,0]
-  this.contourEnable     = true
+  this.contourEnable     = false
 
   this.pickId            = 1
   this.bounds            = [
@@ -102,11 +99,13 @@ function SimplicialMesh(gl
   this.roughness     = 0.5
   this.fresnel       = 1.5
 
-  this.opacity       = 1.0
+  this.opacity       = 1
 
-  this.coneScale     = 2.0
-  this.vectorScale   = 1.0
-  this.coneOffset    = 1.0 / 4.0;
+  this.traceType     = traceType
+  this.tubeScale     = 1 // used in tube
+  this.coneScale     = 2 // used in cone
+  this.vectorScale   = 1 // used in cone
+  this.coneOffset    = 0.25 // used in cone
 
   this._model       = IDENTITY
   this._view        = IDENTITY
@@ -245,14 +244,20 @@ proto.update = function(params) {
     this.fresnel = params.fresnel
   }
 
+  // use in tube
+  if (params.tubeScale !== undefined) {
+    this.tubeScale = params.tubeScale
+  }
+
+  // used in cone
   if (params.vectorScale !== undefined) {
-    this.vectorScale = params.vectorScale;
+    this.vectorScale = params.vectorScale
   }
   if (params.coneScale !== undefined) {
-    this.coneScale = params.coneScale;
+    this.coneScale = params.coneScale
   }
   if (params.coneOffset !== undefined) {
-    this.coneOffset = params.coneOffset;
+    this.coneOffset = params.coneOffset
   }
 
   if(params.texture) {
@@ -295,6 +300,7 @@ proto.update = function(params) {
   //Save geometry data for picking calculations
   this.cells     = cells
   this.positions = positions
+  this.vectors   = vectors
 
   //Compute colors
   var vertexColors    = params.vertexColors
@@ -506,7 +512,7 @@ fill_loop:
           tPos.push(p[0], p[1], p[2], p[3])
 
           var w = vectors[v]
-          tVec.push(w[0], w[1], w[2]);
+          tVec.push(w[0], w[1], w[2], w[3] || 0)
 
           var c
           if(vertexColors) {
@@ -606,6 +612,8 @@ proto.drawTransparent = proto.draw = function(params) {
 
     opacity:  this.opacity,
 
+    tubeScale: this.tubeScale,
+
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
     coneOffset: this.coneOffset,
@@ -652,6 +660,7 @@ proto.drawTransparent = proto.draw = function(params) {
     this.triangleVAO.unbind()
   }
 }
+
 proto.drawPick = function(params) {
   params = params || {}
 
@@ -679,6 +688,7 @@ proto.drawPick = function(params) {
     projection: projection,
     clipBounds: clipBounds,
 
+    tubeScale: this.tubeScale,
     vectorScale: this.vectorScale,
     coneScale: this.coneScale,
     coneOffset: this.coneOffset,
@@ -718,12 +728,23 @@ proto.pick = function(pickData) {
   var cell      = this.cells[cellId]
   var pos =     this.positions[cell[1]].slice(0, 3)
 
-  return {
-    // corresponding to input indices
-    index: Math.floor(cell[1] / 48),
+  var result = {
     position: pos,
-    dataCoordinate: pos
+    dataCoordinate: pos,
+    index: Math.floor(cell[1] / 48)
   }
+
+
+  if(this.traceType === 'cone') {
+    result.index = Math.floor(cell[1] / 48)
+  } else if(this.traceType === 'tube') {
+    result.intensity = this.intensity[cell[1]]
+    result.velocity = this.vectors[cell[1]].slice(0, 3)
+    result.divergence = this.vectors[cell[1]][3]
+    result.index = cellId
+  }
+
+  return result
 }
 
 
@@ -757,10 +778,14 @@ proto.dispose = function() {
   this.contourPositions.dispose()
 }
 
-function createMeshShader(gl) {
-  // need to pass meshShader attributes manually,
-  // to make this work on etpinard's Ubuntu Thinkpad
-  var shader = createShader(gl, meshShader.vertex, meshShader.fragment, null, meshShader.attributes)
+function createMeshShader(gl, shaders) {
+  var shader = createShader(gl,
+    shaders.meshShader.vertex,
+    shaders.meshShader.fragment,
+    null,
+    shaders.meshShader.attributes
+  )
+
   shader.attributes.position.location = 0
   shader.attributes.color.location    = 2
   shader.attributes.uv.location       = 3
@@ -769,8 +794,14 @@ function createMeshShader(gl) {
 }
 
 
-function createPickShader(gl) {
-  var shader = createShader(gl, pickShader.vertex, pickShader.fragment, null, pickShader.attributes)
+function createPickShader(gl, shaders) {
+  var shader = createShader(gl,
+    shaders.pickShader.vertex,
+    shaders.pickShader.fragment,
+    null,
+    shaders.pickShader.attributes
+  )
+
   shader.attributes.position.location = 0
   shader.attributes.id.location       = 1
   shader.attributes.vector.location   = 4
@@ -778,16 +809,17 @@ function createPickShader(gl) {
 }
 
 
+function createSimplicialMesh(gl, params, opts) {
+  var shaders = opts.shaders
 
-function createSimplicialMesh(gl, params) {
   if (arguments.length === 1) {
-    params = gl;
-    gl = params.gl;
+    params = gl
+    gl = params.gl
   }
 
 
-  var triShader       = params.triShader || createMeshShader(gl)
-  var pickShader      = createPickShader(gl)
+  var triShader       = createMeshShader(gl, shaders)
+  var pickShader      = createPickShader(gl, shaders)
   var meshTexture       = createTexture(gl,
     ndarray(new Uint8Array([255,255,255,255]), [1,1,4]))
   meshTexture.generateMipmap()
@@ -819,7 +851,7 @@ function createSimplicialMesh(gl, params) {
     },
     { buffer: triangleVectors,
       type: gl.FLOAT,
-      size: 3
+      size: 4
     }
   ])
 
@@ -905,7 +937,9 @@ function createSimplicialMesh(gl, params) {
     , pointSizes
     , pointVAO
     , contourPositions
-    , contourVAO)
+    , contourVAO
+    , opts.traceType || 'cone'
+  )
 
   mesh.update(params)
 

--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -7,10 +7,7 @@ attribute vec4 position;
 attribute vec4 id;
 
 uniform mat4 model, view, projection;
-
-uniform float vectorScale;
-uniform float coneScale;
-uniform float coneOffset;
+uniform float vectorScale, coneScale, coneOffset;
 
 varying vec3 f_position;
 varying vec4 f_id;

--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -2,7 +2,7 @@ precision highp float;
 
 #pragma glslify: getConePosition = require(./cone-position.glsl)
 
-attribute vec3 vector;
+attribute vec4 vector;
 attribute vec4 position;
 attribute vec4 id;
 
@@ -14,7 +14,7 @@ varying vec4 f_id;
 
 void main() {
   vec3 normal;
-  vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector), position.w, coneOffset, normal);
+  vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector.xyz), position.w, coneOffset, normal);
   vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(XYZ, 0.0);
   gl_Position = projection * view * conePosition;
   f_id        = id;

--- a/lib/shaders.js
+++ b/lib/shaders.js
@@ -10,7 +10,6 @@ exports.meshShader = {
   fragment: triFragSrc,
   attributes: [
     {name: 'position', type: 'vec4'},
-    {name: 'normal', type: 'vec3'},
     {name: 'color', type: 'vec4'},
     {name: 'uv', type: 'vec2'},
     {name: 'vector', type: 'vec3'}

--- a/lib/triangle-fragment.glsl
+++ b/lib/triangle-fragment.glsl
@@ -6,19 +6,10 @@ precision highp float;
 #pragma glslify: outOfRange = require(glsl-out-of-range)
 
 uniform vec3 clipBounds[2];
-uniform float roughness
-            , fresnel
-            , kambient
-            , kdiffuse
-            , kspecular
-            , opacity;
+uniform float roughness, fresnel, kambient, kdiffuse, kspecular, opacity;
 uniform sampler2D texture;
 
-varying vec3 f_normal
-           , f_lightDirection
-           , f_eyeDirection
-           , f_data
-           , f_position;
+varying vec3 f_normal, f_lightDirection, f_eyeDirection, f_data, f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 

--- a/lib/triangle-vertex.glsl
+++ b/lib/triangle-vertex.glsl
@@ -5,23 +5,12 @@ precision highp float;
 attribute vec3 vector;
 attribute vec4 color, position;
 attribute vec2 uv;
-uniform float vectorScale;
-uniform float coneScale;
 
-uniform float coneOffset;
+uniform float vectorScale, coneScale, coneOffset;
+uniform mat4 model, view, projection, inverseModel;
+uniform vec3 eyePosition, lightPosition;
 
-uniform mat4 model
-           , view
-           , projection
-           , inverseModel;
-uniform vec3 eyePosition
-           , lightPosition;
-
-varying vec3 f_normal
-           , f_lightDirection
-           , f_eyeDirection
-           , f_data
-           , f_position;
+varying vec3 f_normal, f_lightDirection, f_eyeDirection, f_data, f_position;
 varying vec4 f_color;
 varying vec2 f_uv;
 
@@ -37,7 +26,7 @@ void main() {
   cameraCoordinate.xyz /= cameraCoordinate.w;
   f_lightDirection = lightPosition - cameraCoordinate.xyz;
   f_eyeDirection   = eyePosition - cameraCoordinate.xyz;
-  f_normal = normalize((vec4(normal,0.0) * inverseModel).xyz);
+  f_normal = normalize((vec4(normal, 0.0) * inverseModel).xyz);
 
   // vec4 m_position  = model * vec4(conePosition, 1.0);
   vec4 t_position  = view * conePosition;

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,14 +50,6 @@
         "pad-left": "^1.0.2"
       }
     },
-    "affine-hull": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
-      "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
-      "requires": {
-        "robust-orientation": "^1.1.3"
-      }
-    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -266,16 +258,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "convex-hull": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
-      "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
-      "requires": {
-        "affine-hull": "^1.0.0",
-        "incremental-convex-hull": "^1.0.1",
-        "monotone-convex-hull-2d": "^1.0.1"
       }
     },
     "core-util-is": {
@@ -902,26 +884,6 @@
         "is-browser": "^2.0.1"
       }
     },
-    "incremental-convex-hull": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
-      "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
-      "requires": {
-        "robust-orientation": "^1.1.2",
-        "simplicial-complex": "^1.0.0"
-      },
-      "dependencies": {
-        "simplicial-complex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
-          "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
-          "requires": {
-            "bit-twiddle": "^1.0.0",
-            "union-find": "^1.0.0"
-          }
-        }
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1016,14 +978,6 @@
         }
       }
     },
-    "marching-simplex-table": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
-      "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
-      "requires": {
-        "convex-hull": "^1.0.3"
-      }
-    },
     "mat4-decompose": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
@@ -1072,14 +1026,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "monotone-convex-hull-2d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
-      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
-      "requires": {
-        "robust-orientation": "^1.1.3"
-      }
     },
     "mouse-change": {
       "version": "1.4.0",
@@ -1142,14 +1088,6 @@
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
       "requires": {
         "cwise-compiler": "^1.0.0"
-      }
-    },
-    "ndarray-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
-      "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
-      "requires": {
-        "typedarray-pool": "^1.0.0"
       }
     },
     "nextafter": {
@@ -1441,6 +1379,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "dev": true,
       "requires": {
         "robust-scale": "^1.0.2",
         "robust-subtract": "^1.0.0",
@@ -1462,6 +1401,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "dev": true,
       "requires": {
         "two-product": "^1.0.2",
         "two-sum": "^1.0.0"
@@ -1479,12 +1419,14 @@
     "robust-subtract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
-      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo=",
+      "dev": true
     },
     "robust-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
-      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -1524,17 +1466,6 @@
           "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY=",
           "dev": true
         }
-      }
-    },
-    "simplicial-complex-contour": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
-      "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
-      "requires": {
-        "marching-simplex-table": "^1.0.0",
-        "ndarray": "^1.0.15",
-        "ndarray-sort": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
       }
     },
     "simplify-planar-graph": {
@@ -1812,12 +1743,14 @@
     "two-product": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
-      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo=",
+      "dev": true
     },
     "two-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
-      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -1870,7 +1803,8 @@
     "union-find": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
-      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg=",
+      "dev": true
     },
     "uniq": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,15 +81,6 @@
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
       "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
     },
-    "barycentric": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
-      "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
-      "dev": true,
-      "requires": {
-        "robust-linear-solve": "^1.0.0"
-      }
-    },
     "big-rat": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
@@ -597,29 +588,6 @@
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
     },
-    "gl-mesh3d": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.1.1.tgz",
-      "integrity": "sha512-UuDnuSE/xX8y9/B6EtDsBKllEmKDVmuiD9lsFoQdUq4FPSvwFOo9rKH3fsjK2pfxsTigguF6GhFjHqq+sJKQWg==",
-      "dev": true,
-      "requires": {
-        "barycentric": "^1.0.1",
-        "colormap": "^2.3.1",
-        "gl-buffer": "^2.0.8",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.8",
-        "gl-vao": "^1.1.3",
-        "glsl-out-of-range": "^1.0.4",
-        "glsl-specular-cook-torrance": "^2.0.1",
-        "glslify": "^7.0.0",
-        "ndarray": "^1.0.15",
-        "normals": "^1.0.1",
-        "polytope-closest-point": "^1.0.0",
-        "simplicial-complex-contour": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
-      }
-    },
     "gl-quat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
@@ -753,14 +721,12 @@
     "glsl-specular-beckmann": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
-      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE=",
-      "dev": true
+      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
     },
     "glsl-specular-cook-torrance": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
-      "dev": true,
       "requires": {
         "glsl-specular-beckmann": "^1.1.1"
       }
@@ -1195,17 +1161,6 @@
         "double-bits": "^1.1.0"
       }
     },
-    "normals": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
-      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
-    },
-    "numeric": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao=",
-      "dev": true
-    },
     "object-inspect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
@@ -1321,15 +1276,6 @@
         "interval-tree-1d": "^1.0.1",
         "robust-orientation": "^1.1.3",
         "slab-decomposition": "^1.0.1"
-      }
-    },
-    "polytope-closest-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
-      "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
-      "dev": true,
-      "requires": {
-        "numeric": "^1.2.6"
       }
     },
     "prelude-ls": {
@@ -1469,24 +1415,6 @@
       "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg=",
       "dev": true
     },
-    "robust-compress": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
-      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs=",
-      "dev": true
-    },
-    "robust-determinant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
-      "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
-      "dev": true,
-      "requires": {
-        "robust-compress": "^1.0.0",
-        "robust-scale": "^1.0.0",
-        "robust-sum": "^1.0.0",
-        "two-product": "^1.0.0"
-      }
-    },
     "robust-dot-product": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
@@ -1507,15 +1435,6 @@
         "robust-subtract": "^1.0.0",
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.0"
-      }
-    },
-    "robust-linear-solve": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
-      "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
-      "dev": true,
-      "requires": {
-        "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "gl-vec3": "^1.1.3",
     "glsl-inverse": "^1.0.0",
     "glsl-out-of-range": "^1.0.4",
+    "glsl-specular-cook-torrance": "^2.0.1",
     "glslify": "^7.0.0",
     "ndarray": "^1.0.18",
-    "normals": "^1.1.0",
     "simplicial-complex-contour": "^1.0.2",
     "typedarray-pool": "^1.1.0"
   },
@@ -28,7 +28,6 @@
     "canvas-fit": "^1.5.0",
     "chttps": "^1.0.6",
     "gl-axes3d": "^1.5.2",
-    "gl-mesh3d": "^2.1.1",
     "gl-select-static": "^2.0.4",
     "gl-spikes3d": "^1.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "glsl-out-of-range": "^1.0.4",
     "glsl-specular-cook-torrance": "^2.0.1",
     "glslify": "^7.0.0",
-    "ndarray": "^1.0.18",
-    "simplicial-complex-contour": "^1.0.2",
-    "typedarray-pool": "^1.1.0"
+    "ndarray": "^1.0.18"
   },
   "devDependencies": {
     "3d-view-controls": "^2.2.2",


### PR DESCRIPTION
In addition to dropping unused complexities `normals`, `countours`, `lines` and `points` (i.e. copied from `gl-mesh3d`), this PR makes `lib/conemesh.js` reusable for `gl-streamtube3d`.

Also to note `gl-mesh3d` used to be installed as a dev dependency; whereas `glsl-specular-cook-torrance` should have been installed as a actual dependency. That is now fixed in this PR.

cc: @etpinard 