### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/lib/pick-vertex.glsl
+++ b/lib/pick-vertex.glsl
@@ -16,7 +16,7 @@ void main() {
   vec3 normal;
   vec3 XYZ = getConePosition(mat3(model) * ((vectorScale * coneScale) * vector.xyz), position.w, coneOffset, normal);
   vec4 conePosition = model * vec4(position.xyz, 1.0) + vec4(XYZ, 0.0);
-  gl_Position = projection * view * conePosition;
+  gl_Position = projection * (view * conePosition);
   f_id        = id;
   f_position  = position.xyz;
 }


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23
